### PR TITLE
IVD-321 - Custom Taxonomy Filtering

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,8 @@
         "bonnier/wp-bonnier-redirect": "^2.0",
         "bonnier/wp-bonnier-some": "^2.0",
         "bonnier/wp-focal-point": "^1.1",
-        "league/csv": "^9.1"
+        "league/csv": "^9.1",
+        "wpackagist-plugin/wp-rest-filter": "^1.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b7ad2795411a6346505deff9e755dc67",
+    "content-hash": "23f449658cfe86cf4088b0349803fb23",
     "packages": [
         {
             "name": "benjaminmedia/wp-cxense",
@@ -1598,6 +1598,26 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/user-role-editor/"
+        },
+        {
+            "name": "wpackagist-plugin/wp-rest-filter",
+            "version": "1.2.5",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/wp-rest-filter/",
+                "reference": "tags/1.2.5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/wp-rest-filter.1.2.5.zip",
+                "reference": null,
+                "shasum": null
+            },
+            "require": {
+                "composer/installers": "~1.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/wp-rest-filter/"
         }
     ],
     "packages-dev": [

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/benjaminmedia/willow-base-theme
 Author: Bonnier Publications
 Author URI: https://github.com/benjaminmedia
 Description: Willow Base theme for WordPress - A full WordPress REST API - no frontend at all.
-Version: 1.0.29
+Version: 1.1.0
 License: GNU General Public License
 License URI: https://www.gnu.org/licenses/gpl.html
 */


### PR DESCRIPTION
Since filtering in the WordPress API was removed in 4.7, we've added a plugin to add this functionality again.