### PR TITLE
Bugfix - Pages fails when no ACF Fields are set on it.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1941,16 +1941,16 @@
         },
         {
             "name": "composer/ca-bundle",
-            "version": "1.1.2",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "46afded9720f40b9dc63542af4e3e43a1177acb0"
+                "reference": "8afa52cd417f4ec417b4bfe86b68106538a87660"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/46afded9720f40b9dc63542af4e3e43a1177acb0",
-                "reference": "46afded9720f40b9dc63542af4e3e43a1177acb0",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/8afa52cd417f4ec417b4bfe86b68106538a87660",
+                "reference": "8afa52cd417f4ec417b4bfe86b68106538a87660",
                 "shasum": ""
             },
             "require": {
@@ -1993,7 +1993,7 @@
                 "ssl",
                 "tls"
             ],
-            "time": "2018-08-08T08:57:40+00:00"
+            "time": "2018-10-18T06:09:13+00:00"
         },
         {
             "name": "composer/composer",

--- a/src/Adapters/Wp/Composites/CompositeAdapter.php
+++ b/src/Adapters/Wp/Composites/CompositeAdapter.php
@@ -90,7 +90,7 @@ class CompositeAdapter extends AbstractWpAdapter implements CompositeContract
         if ($postId = data_get($this->wpModel, 'ID')) {
             $this->acfFields = get_fields($postId);
         }
-        $this->compositeContents = array_get($this->acfFields, 'composite_content', []);
+        $this->compositeContents = array_get($this->acfFields, 'composite_content') ?: null;
     }
 
     public function getAcfFields()

--- a/src/Adapters/Wp/Pages/PageAdapter.php
+++ b/src/Adapters/Wp/Pages/PageAdapter.php
@@ -55,7 +55,7 @@ class PageAdapter extends AbstractWpAdapter implements PageContract
         parent::__construct($page);
 
         $this->acfFields = get_fields($this->wpModel->ID);
-        $this->pageContents = $this->acfFields[AcfName::GROUP_PAGE_WIDGETS] ?? null;
+        $this->pageContents = array_get($this->acfFields, AcfName::GROUP_PAGE_WIDGETS) ?: null;
     }
 
     public function getAcfFields()

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/benjaminmedia/willow-base-theme
 Author: Bonnier Publications
 Author URI: https://github.com/benjaminmedia
 Description: Willow Base theme for WordPress - A full WordPress REST API - no frontend at all.
-Version: 1.19.2
+Version: 1.19.3
 License: GNU General Public License
 License URI: https://www.gnu.org/licenses/gpl.html
 */


### PR DESCRIPTION
If no widgets are added to a Page in WordPress, `$this->acfFields[AcfName::GROUP_PAGE_WIDGETS]` would return `false` instead of an empty array, which would cause the method `getContents()` to fail, because it would try to map on a collection containing one value that is `false`.
Hence a fallback to null, if a falsey value is returned on PageAdapter and CompositeAdapter, to avoid errors being thrown when no ACF Fields are set.