### PR TITLE
Refactor - Fixing stories/associated content

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -100,16 +100,16 @@
         },
         {
             "name": "bonnier/contenthub-editor",
-            "version": "3.20.1",
+            "version": "3.22.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/BenjaminMedia/wp-contenthub-editor.git",
-                "reference": "3ee2f2fac6a8db50e2d97916947f48e5f72c5fd0"
+                "reference": "b91c5fd7e2d24b226d4a95eb9859382fd1d63581"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/BenjaminMedia/wp-contenthub-editor/zipball/3ee2f2fac6a8db50e2d97916947f48e5f72c5fd0",
-                "reference": "3ee2f2fac6a8db50e2d97916947f48e5f72c5fd0",
+                "url": "https://api.github.com/repos/BenjaminMedia/wp-contenthub-editor/zipball/b91c5fd7e2d24b226d4a95eb9859382fd1d63581",
+                "reference": "b91c5fd7e2d24b226d4a95eb9859382fd1d63581",
                 "shasum": ""
             },
             "require": {
@@ -152,7 +152,7 @@
                 "plugin",
                 "wordpress"
             ],
-            "time": "2018-11-02T13:19:04+00:00"
+            "time": "2018-11-05T14:25:11+00:00"
         },
         {
             "name": "bonnier/php-video-helper",

--- a/src/Adapters/Cxense/Search/DocumentAdapter.php
+++ b/src/Adapters/Cxense/Search/DocumentAdapter.php
@@ -2,6 +2,7 @@
 
 namespace Bonnier\Willow\Base\Adapters\Cxense\Search;
 
+use Bonnier\Willow\Base\Models\Contracts\Composites\Contents\StoryContract;
 use Bonnier\Willow\Base\Models\Contracts\Root\AudioContract;
 use Bonnier\WP\Cxense\Parsers\Document;
 use Bonnier\Willow\Base\Adapters\Cxense\Search\Partials\DocumentTeaserAdapter;
@@ -186,10 +187,10 @@ class DocumentAdapter implements CompositeContract
         return null;
     }
 
-    public function getAssociatedComposites(): ?Collection
+    public function getStory(): ?StoryContract
     {
         // todo find the right field
-        return collect([]);
+        return null;
     }
 
     public function getAudio(): ?AudioContract

--- a/src/Adapters/Wp/App/InstagramCompositeAdapter.php
+++ b/src/Adapters/Wp/App/InstagramCompositeAdapter.php
@@ -7,6 +7,7 @@ use Bonnier\Willow\Base\Adapters\Wp\App\Partials\SocialFeedImageAdapter;
 use Bonnier\Willow\Base\Models\Base\Composites\Contents\Types\ContentImage;
 use Bonnier\Willow\Base\Models\Base\Root\Teaser;
 use Bonnier\Willow\Base\Models\Contracts\Composites\CompositeContract;
+use Bonnier\Willow\Base\Models\Contracts\Composites\Contents\StoryContract;
 use Bonnier\Willow\Base\Models\Contracts\Composites\Contents\Types\ContentImageContract;
 use Bonnier\Willow\Base\Models\Contracts\Root\AudioContract;
 use Bonnier\Willow\Base\Models\Contracts\Root\AuthorContract;
@@ -181,7 +182,7 @@ class InstagramCompositeAdapter implements CompositeContract
         return null;
     }
 
-    public function getAssociatedComposites(): ?Collection
+    public function getStory(): ?StoryContract
     {
         return null;
     }

--- a/src/Adapters/Wp/App/PinterestCompositeAdapter.php
+++ b/src/Adapters/Wp/App/PinterestCompositeAdapter.php
@@ -7,6 +7,7 @@ use Bonnier\Willow\Base\Adapters\Wp\App\Partials\SocialFeedTeaserAdapter;
 use Bonnier\Willow\Base\Models\Base\Composites\Contents\Types\ContentImage;
 use Bonnier\Willow\Base\Models\Base\Root\Teaser;
 use Bonnier\Willow\Base\Models\Contracts\Composites\CompositeContract;
+use Bonnier\Willow\Base\Models\Contracts\Composites\Contents\StoryContract;
 use Bonnier\Willow\Base\Models\Contracts\Composites\Contents\Types\ContentImageContract;
 use Bonnier\Willow\Base\Models\Contracts\Root\AudioContract;
 use Bonnier\Willow\Base\Models\Contracts\Root\AuthorContract;
@@ -182,7 +183,7 @@ class PinterestCompositeAdapter implements CompositeContract
         return null;
     }
 
-    public function getAssociatedComposites(): ?Collection
+    public function getStory(): ?StoryContract
     {
         return null;
     }

--- a/src/Adapters/Wp/Composites/CompositeAdapter.php
+++ b/src/Adapters/Wp/Composites/CompositeAdapter.php
@@ -3,7 +3,7 @@
 namespace Bonnier\Willow\Base\Adapters\Wp\Composites;
 
 use Bonnier\Willow\Base\Adapters\Wp\AbstractWpAdapter;
-use Bonnier\Willow\Base\Adapters\Wp\Composites\Contents\Types\AssociatedContentAdapter;
+use Bonnier\Willow\Base\Adapters\Wp\Composites\Contents\StoryAdapter;
 use Bonnier\Willow\Base\Adapters\Wp\Composites\Contents\Types\ContentAudioAdapter;
 use Bonnier\Willow\Base\Adapters\Wp\Composites\Contents\Types\ContentImageAdapter;
 use Bonnier\Willow\Base\Adapters\Wp\Root\AuthorAdapter;
@@ -13,6 +13,7 @@ use Bonnier\Willow\Base\Adapters\Wp\Terms\Tags\TagAdapter;
 use Bonnier\Willow\Base\Adapters\Wp\Terms\Vocabulary\VocabularyAdapter;
 use Bonnier\Willow\Base\Factories\CompositeContentFactory;
 use Bonnier\Willow\Base\Factories\Contracts\ModelFactoryContract;
+use Bonnier\Willow\Base\Models\Base\Composites\Contents\Story;
 use Bonnier\Willow\Base\Models\Base\Composites\Contents\Types\AssociatedContent;
 use Bonnier\Willow\Base\Models\Base\Composites\Contents\Types\ContentAudio;
 use Bonnier\Willow\Base\Models\Base\Composites\Contents\Types\ContentFile;
@@ -35,6 +36,7 @@ use Bonnier\Willow\Base\Models\Base\Terms\Tag;
 use Bonnier\Willow\Base\Models\Base\Terms\Vocabulary;
 use Bonnier\Willow\Base\Models\Contracts\Composites\CompositeContract;
 use Bonnier\Willow\Base\Models\Contracts\Composites\Contents\ContentContract;
+use Bonnier\Willow\Base\Models\Contracts\Composites\Contents\StoryContract;
 use Bonnier\Willow\Base\Models\Contracts\Composites\Contents\Types\ContentFileContract;
 use Bonnier\Willow\Base\Models\Contracts\Composites\Contents\Types\ContentImageContract;
 use Bonnier\Willow\Base\Models\Contracts\Root\AudioContract;
@@ -322,19 +324,12 @@ class CompositeAdapter extends AbstractWpAdapter implements CompositeContract
         return intval(get_post_meta($this->getId(), 'reading_time', true)) ?: 0;
     }
 
-    public function getAssociatedComposites(): ?Collection
+    public function getStory(): ?StoryContract
     {
-        if ($storyCompositeId = get_post_meta($this->getId(), 'story_parent', true)) {
-            if ($associatedComposites = get_field('composite_content', $storyCompositeId)) {
-                return collect($associatedComposites)->map(function ($acfArray) {
-                    if (array_get($acfArray, 'acf_fc_layout') === 'associated_composite') {
-                        return new AssociatedContent(new AssociatedContentAdapter($acfArray));
-                    }
-                    return null;
-                })->reject(function ($associatedContent) {
-                    return is_null($associatedContent);
-                });
-            }
+        if (($storyCompositeId = get_post_meta($this->getId(), 'story_parent', true)) &&
+            $storyComposite = get_post($storyCompositeId)
+        ) {
+            return new Story(new StoryAdapter($storyComposite));
         }
         return null;
     }

--- a/src/Adapters/Wp/Composites/Contents/StoryAdapter.php
+++ b/src/Adapters/Wp/Composites/Contents/StoryAdapter.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Bonnier\Willow\Base\Adapters\Wp\Composites\Contents;
+
+use Bonnier\Willow\Base\Adapters\Wp\Composites\CompositeAdapter;
+use Bonnier\Willow\Base\Models\Base\Composites\Composite;
+use Bonnier\Willow\Base\Models\Contracts\Composites\CompositeContract;
+use Bonnier\Willow\Base\Models\Contracts\Composites\Contents\StoryContract;
+use Illuminate\Support\Collection;
+
+class StoryAdapter implements StoryContract
+{
+    protected $composite;
+
+    public function __construct(\WP_Post $composite)
+    {
+        $this->composite = $composite;
+    }
+
+    public function getTeaser(): ?CompositeContract
+    {
+        return new Composite(new CompositeAdapter($this->composite));
+    }
+
+    public function getArticles(): ?Collection
+    {
+        $articles = collect(get_field('composite_content', $this->composite->ID) ?? [])
+            ->map(function ($content) {
+                if (array_get($content, 'acf_fc_layout') === 'associated_composite' &&
+                    ($composite = array_get($content, 'composite.0')) &&
+                    $composite instanceof \WP_Post) {
+                    return new Composite(new CompositeAdapter($composite));
+                }
+                return null;
+            })
+            ->reject(function ($content) {
+                return is_null($content);
+            });
+
+        return $articles->isNotEmpty() ? $articles : null;
+    }
+}

--- a/src/Factories/CompositeContentFactory.php
+++ b/src/Factories/CompositeContentFactory.php
@@ -3,7 +3,6 @@
 namespace Bonnier\Willow\Base\Factories;
 
 use Bonnier\Willow\Base\Adapters\Wp\Composites\CompositeAdapter;
-use Bonnier\Willow\Base\Adapters\Wp\Composites\CompositeTeaserAdapter;
 use Bonnier\Willow\Base\Adapters\Wp\Composites\Contents\Types\AssociatedContentAdapter;
 use Bonnier\Willow\Base\Adapters\Wp\Composites\Contents\Types\ContentAudioAdapter;
 use Bonnier\Willow\Base\Adapters\Wp\Composites\Contents\Types\ContentFileAdapter;

--- a/src/Models/Base/Composites/Composite.php
+++ b/src/Models/Base/Composites/Composite.php
@@ -3,11 +3,11 @@
 namespace Bonnier\Willow\Base\Models\Base\Composites;
 
 use Bonnier\Willow\Base\Models\Contracts\Composites\CompositeContract;
+use Bonnier\Willow\Base\Models\Contracts\Composites\Contents\StoryContract;
 use Bonnier\Willow\Base\Models\Contracts\Composites\Contents\Types\ContentImageContract;
 use Bonnier\Willow\Base\Models\Contracts\Root\AudioContract;
 use Bonnier\Willow\Base\Models\Contracts\Root\AuthorContract;
 use Bonnier\Willow\Base\Models\Contracts\Root\CommercialContract;
-use Bonnier\Willow\Base\Models\Contracts\Root\ImageContract;
 use Bonnier\Willow\Base\Models\Contracts\Root\TeaserContract;
 use Bonnier\Willow\Base\Models\Contracts\Terms\CategoryContract;
 use DateTime;
@@ -162,9 +162,9 @@ class Composite implements CompositeContract
         return $this->composite->getEstimatedReadingTime();
     }
 
-    public function getAssociatedComposites(): ?Collection
+    public function getStory(): ?StoryContract
     {
-        return $this->composite->getAssociatedComposites();
+        return $this->composite->getStory();
     }
 
     public function getParent(): ?int

--- a/src/Models/Base/Composites/Contents/Story.php
+++ b/src/Models/Base/Composites/Contents/Story.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Bonnier\Willow\Base\Models\Base\Composites\Contents;
+
+use Bonnier\Willow\Base\Models\Contracts\Composites\CompositeContract;
+use Bonnier\Willow\Base\Models\Contracts\Composites\Contents\StoryContract;
+use Illuminate\Support\Collection;
+
+class Story implements StoryContract
+{
+    protected $story;
+
+    public function __construct(StoryContract $story)
+    {
+        $this->story = $story;
+    }
+
+    public function getTeaser(): ?CompositeContract
+    {
+        return $this->story->getTeaser();
+    }
+
+    public function getArticles(): ?Collection
+    {
+        return $this->story->getArticles();
+    }
+}

--- a/src/Models/Contracts/Composites/CompositeContract.php
+++ b/src/Models/Contracts/Composites/CompositeContract.php
@@ -2,11 +2,11 @@
 
 namespace Bonnier\Willow\Base\Models\Contracts\Composites;
 
+use Bonnier\Willow\Base\Models\Contracts\Composites\Contents\StoryContract;
 use Bonnier\Willow\Base\Models\Contracts\Composites\Contents\Types\ContentImageContract;
 use Bonnier\Willow\Base\Models\Contracts\Root\AudioContract;
 use Bonnier\Willow\Base\Models\Contracts\Root\AuthorContract;
 use Bonnier\Willow\Base\Models\Contracts\Root\CommercialContract;
-use Bonnier\Willow\Base\Models\Contracts\Root\ImageContract;
 use Bonnier\Willow\Base\Models\Contracts\Root\TeaserContract;
 use Bonnier\Willow\Base\Models\Contracts\Terms\CategoryContract;
 use DateTime;
@@ -68,7 +68,7 @@ interface CompositeContract
 
     public function getEstimatedReadingTime(): ?int;
 
-    public function getAssociatedComposites(): ?Collection;
+    public function getStory(): ?StoryContract;
 
     public function getAudio(): ?AudioContract;
 

--- a/src/Models/Contracts/Composites/Contents/StoryContract.php
+++ b/src/Models/Contracts/Composites/Contents/StoryContract.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Bonnier\Willow\Base\Models\Contracts\Composites\Contents;
+
+use Bonnier\Willow\Base\Models\Contracts\Composites\CompositeContract;
+use Illuminate\Support\Collection;
+
+interface StoryContract
+{
+    public function getTeaser(): ?CompositeContract;
+
+    public function getArticles(): ?Collection;
+}

--- a/src/Transformers/Api/Composites/CompositeTeaserTransformer.php
+++ b/src/Transformers/Api/Composites/CompositeTeaserTransformer.php
@@ -22,8 +22,7 @@ class CompositeTeaserTransformer extends TransformerAbstract
      * @var array
      */
     protected $availableIncludes = [
-        'vocabularies',
-        'associated'
+        'vocabularies'
     ];
 
     /**
@@ -89,12 +88,5 @@ class CompositeTeaserTransformer extends TransformerAbstract
     public function includeVocabularies(CompositeContract $composite)
     {
         return $this->collection($composite->getVocabularies(), new VocabularyTransformer());
-    }
-
-    public function includeAssociated(CompositeContract $composite){
-        if(!$composite->getKind() || ($composite->getKind() !== 'Story')){
-            return [];
-        }
-        return $this->collection($composite->getAssociatedComposites(), new CompositeTeaserTransformer());
     }
 }

--- a/src/Transformers/Api/Composites/CompositeTransformer.php
+++ b/src/Transformers/Api/Composites/CompositeTransformer.php
@@ -3,6 +3,7 @@
 namespace Bonnier\Willow\Base\Transformers\Api\Composites;
 
 use Bonnier\Willow\Base\Models\Contracts\Composites\Contents\Types\AssociatedContentContract;
+use Bonnier\Willow\Base\Transformers\Api\Composites\Includes\Contents\StoryTransformer;
 use Bonnier\Willow\Base\Transformers\Api\Composites\Includes\Contents\Types\ContentAudioTransformer;
 use Bonnier\Willow\Base\Transformers\Api\Terms\Vocabulary\VocabularyTransformer;
 use Bonnier\Willow\Base\Traits\UrlTrait;
@@ -44,7 +45,7 @@ class CompositeTransformer extends TransformerAbstract
         'teasers',
         'tags',
         'vocabularies',
-        'associated_content'
+        'story'
     ];
 
     protected $defaultIncludes = [
@@ -205,12 +206,10 @@ class CompositeTransformer extends TransformerAbstract
         return $this->collection($content, new CompositeTeaserTransformer());
     }
 
-    public function includeAssociatedContent(CompositeContract $composite)
+    public function includeStory(CompositeContract $composite)
     {
-        if (($associatedContents = $composite->getAssociatedComposites()) && $associatedContents->isNotEmpty()) {
-            return $this->collection($associatedContents->map(function (AssociatedContentContract $content) {
-                return $content->getAssociatedComposite();
-            }), new CompositeTeaserTransformer);
+        if ($story = $composite->getStory()) {
+            return $this->item($story, new StoryTransformer);
         }
 
         return null;

--- a/src/Transformers/Api/Composites/Includes/Contents/StoryTransformer.php
+++ b/src/Transformers/Api/Composites/Includes/Contents/StoryTransformer.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Bonnier\Willow\Base\Transformers\Api\Composites\Includes\Contents;
+
+use Bonnier\Willow\Base\Models\Contracts\Composites\CompositeContract;
+use Bonnier\Willow\Base\Models\Contracts\Composites\Contents\StoryContract;
+use Bonnier\Willow\Base\Transformers\Api\Composites\CompositeTeaserTransformer;
+use League\Fractal\TransformerAbstract;
+
+class StoryTransformer extends TransformerAbstract
+{
+    public function transform(StoryContract $story)
+    {
+        return [
+            'teaser' => $this->transformTeaser($story),
+            'articles' => $this->transformArticles($story),
+        ];
+    }
+
+    private function transformTeaser(StoryContract $story)
+    {
+        return with(new CompositeTeaserTransformer)->transform($story->getTeaser());
+    }
+
+    private function transformArticles(StoryContract $story)
+    {
+        if ($articles = $story->getArticles()) {
+            return $articles->map(function (CompositeContract $composite) {
+                return with(new CompositeTeaserTransformer)->transform($composite);
+            });
+        }
+
+        return null;
+    }
+}

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/benjaminmedia/willow-base-theme
 Author: Bonnier Publications
 Author URI: https://github.com/benjaminmedia
 Description: Willow Base theme for WordPress - A full WordPress REST API - no frontend at all.
-Version: 1.33.1
+Version: 1.34.0
 License: GNU General Public License
 License URI: https://www.gnu.org/licenses/gpl.html
 */


### PR DESCRIPTION
Articles that are part of a story will now display the parent story composite teaser alongside teasers for all articles in that story.