### PR TITLE
Bugfix - Color Palette

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1170,16 +1170,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "1.34.1",
+            "version": "1.34.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "19201b87f7dba2a7cbf1cccdf0e1da13c04ee9c9"
+                "reference": "b9a444d829c9a16735aceca1b173e765745bcc0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/19201b87f7dba2a7cbf1cccdf0e1da13c04ee9c9",
-                "reference": "19201b87f7dba2a7cbf1cccdf0e1da13c04ee9c9",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/b9a444d829c9a16735aceca1b173e765745bcc0c",
+                "reference": "b9a444d829c9a16735aceca1b173e765745bcc0c",
                 "shasum": ""
             },
             "require": {
@@ -1187,8 +1187,11 @@
                 "symfony/translation": "~2.6 || ~3.0 || ~4.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "~2",
                 "phpunit/phpunit": "^4.8.35 || ^5.7"
+            },
+            "suggest": {
+                "friendsofphp/php-cs-fixer": "Needed for the `composer phpcs` command. Allow to automatically fix code style.",
+                "phpstan/phpstan": "Needed for the `composer phpstan` command. Allow to detect potential errors."
             },
             "type": "library",
             "extra": {
@@ -1221,7 +1224,7 @@
                 "datetime",
                 "time"
             ],
-            "time": "2018-11-08T13:33:47+00:00"
+            "time": "2018-11-13T08:26:10+00:00"
         },
         {
             "name": "paragonie/random_compat",

--- a/src/Adapters/Wp/Root/ColorPaletteAdapter.php
+++ b/src/Adapters/Wp/Root/ColorPaletteAdapter.php
@@ -23,7 +23,11 @@ class ColorPaletteAdapter implements ColorPaletteContract
             update_post_meta($attachmentId, self::COLOR_PALETTE_META, $this->rawPalette);
         }
 
-        $this->rawPalette = json_decode($this->rawPalette);
+        // WordPress might have saved a serialized meta field
+        // and will then return an object instead of a json encoded string.
+        if (is_string($this->rawPalette)) {
+            $this->rawPalette = json_decode($this->rawPalette);
+        }
     }
 
     public function getColors(): ?Collection

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/benjaminmedia/willow-base-theme
 Author: Bonnier Publications
 Author URI: https://github.com/benjaminmedia
 Description: Willow Base theme for WordPress - A full WordPress REST API - no frontend at all.
-Version: 1.38.3
+Version: 1.38.4
 License: GNU General Public License
 License URI: https://www.gnu.org/licenses/gpl.html
 */


### PR DESCRIPTION
WordPress might save a serialised object instead of a json encoded string, and will deserialise it on retrieval.
Therefore we need to test if the property is a string, it needs to be decoded, otherwise it's ready for use.