### PR TITLE
Bugfix - Fixing error thrown in galleries

### DIFF
--- a/src/Transformers/Api/Composites/Includes/Contents/Types/GalleryTransformer.php
+++ b/src/Transformers/Api/Composites/Includes/Contents/Types/GalleryTransformer.php
@@ -22,11 +22,23 @@ class GalleryTransformer extends TransformerAbstract
             'title' => $gallery->getTitle(),
             'description' => $gallery->getDescription(),
             'display_hint' => $gallery->getDisplayHint(),
-            'images' => $gallery->isLocked() ?
-                null :
-                $gallery->getImages()->map(function (GalleryImageContract $galleryImage) {
-                    return with(new GalleryImageTransformer())->transform($galleryImage);
-                }),
+            'images' => $this->getImages($gallery),
         ];
+    }
+
+    private function getImages(GalleryContract $gallery)
+    {
+        if ($gallery->isLocked() || $gallery->getImages()->isEmpty()) {
+            return null;
+        }
+
+        return $gallery->getImages()->map(function (GalleryImageContract $galleryImage) {
+            if ($galleryImage->getImage() && $galleryImage->getImage()->getUrl()) {
+                return with(new GalleryImageTransformer())->transform($galleryImage);
+            }
+            return null;
+        })->reject(function ($galleryImage) {
+            return is_null($galleryImage);
+        });
     }
 }

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/benjaminmedia/willow-base-theme
 Author: Bonnier Publications
 Author URI: https://github.com/benjaminmedia
 Description: Willow Base theme for WordPress - A full WordPress REST API - no frontend at all.
-Version: 1.40.1
+Version: 1.40.2
 License: GNU General Public License
 License URI: https://www.gnu.org/licenses/gpl.html
 */


### PR DESCRIPTION
If a gallery contained an empty image, an error would be thrown.
This fix is rejecting all invalid images from the gallery.