### PR TITLE
Hotfix for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     docker:
     # specify the version you desire here
-    - image: circleci/php:7.1-fpm-browsers
+    - image: circleci/php@sha256:c3620fee1d114bb949e2ace7ff51207dd13d26c5af5aa8eecbc794562adbd61f
 
     # Specify service dependencies here if necessary
     # CircleCI maintains a library of pre-built images


### PR DESCRIPTION
Circle-CI has screwed up latest build of there image. Therefor I've added the there latest working sha value, so we can use it until they fix the issue.

I reported the issue to Circle-CI.