### PR TITLE
IVD-479 - Category and composite slug collides 

### DIFF
--- a/src/Controllers/App/RouteController.php
+++ b/src/Controllers/App/RouteController.php
@@ -221,8 +221,14 @@ class RouteController extends BaseController
 
         $content = null;
 
-        foreach ($parts as $part) {
-            if ($category = get_category_by_slug($part)) {
+        $lastPartIndex = count($parts) - 1;
+
+        foreach ($parts as $index => $part) {
+            // The last part of the path, should be the postname of the composite
+            // We need to skip checking if the last part is a category, in the case
+            // the category slug and the composite slug are the same. For instance
+            // https://willow-site.com/top-category/subject/subject
+            if ($index < $lastPartIndex && $category = get_category_by_slug($part)) {
                 if ($content && !$content instanceof WP_Term) {
                     return null;
                 } elseif ($content && $category->parent !== $content->term_id) {

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/benjaminmedia/willow-base-theme
 Author: Bonnier Publications
 Author URI: https://github.com/benjaminmedia
 Description: Willow Base theme for WordPress - A full WordPress REST API - no frontend at all.
-Version: 1.45.3
+Version: 1.45.4
 License: GNU General Public License
 License URI: https://www.gnu.org/licenses/gpl.html
 */

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/benjaminmedia/willow-base-theme
 Author: Bonnier Publications
 Author URI: https://github.com/benjaminmedia
 Description: Willow Base theme for WordPress - A full WordPress REST API - no frontend at all.
-Version: 1.45.2
+Version: 1.45.3
 License: GNU General Public License
 License URI: https://www.gnu.org/licenses/gpl.html
 */


### PR DESCRIPTION
We had an issue where, if the category slug was identical to the composite slug, the route resolver would return 404.
I've updated the RouteController to not check if the path part is a category, if it's the last item in the path and we are testing for composites.
In that way, we'll be able to support categories and composites with identical slugs.