### PR TITLE
IVD-470/feature: added author clean up WP CLI command

### DIFF
--- a/src/Commands/AuthorFix.php
+++ b/src/Commands/AuthorFix.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Bonnier\Willow\Base\Commands;
+
+use Bonnier\WP\ContentHub\Editor\Commands\CmdManager;
+use Bonnier\WP\ContentHub\Editor\Models\WpComposite;
+use WP_CLI;
+use WP_CLI_Command;
+
+class AuthorFix extends WP_CLI_Command
+{
+    const CMD_NAMESPACE = 'author';
+
+    public static function register()
+    {
+        WP_CLI::add_command(CmdManager::CORE_CMD_NAMESPACE  . ' ' . static::CMD_NAMESPACE, __CLASS__);
+    }
+
+    /**
+     * Prints a greeting.
+     *
+     * ## OPTIONS
+     *
+     * <locale>
+     * : The locale you want to use to find composites.
+     * <author>
+     * : The id of the user you want to set all composites to.
+     * ---
+     *
+     * ## EXAMPLES
+     *
+     *     wp contenteditor author fix da 3
+     *
+     */
+    public function fix($args)
+    {
+        if (count($args) < 2) {
+            WP_CLI::error('please provide both locale and author example:');
+            WP_CLI::error(sprintf('%s author fix da 3', CmdManager::CORE_CMD_NAMESPACE));
+        }
+
+        $locale = $args[0];
+        $author = $args[1];
+
+        $posts = get_posts([
+            'lang' => $locale,
+            'post_type' => WpComposite::POST_TYPE,
+            'numberposts' => -1,
+            'author' => 1,
+        ]);
+
+        $amountOfPosts = count($posts);
+
+        WP_CLI::line(sprintf('found %s composites with locale: %s', $amountOfPosts, $locale));
+
+        if ($amountOfPosts > 0) {
+            foreach ($posts as $post) {
+                WP_CLI::runcommand(sprintf('post update %d --post_author=%d', $post->ID, $author));
+            }
+        }
+    }
+
+    public function fixAll()
+    {
+        $users = [
+            'da' => 'Redaktionen',
+            'sv' => 'Redaktionen',
+            'nb' => 'Redaksjonen',
+            'fi' => 'Toimitus',
+            'nl' => 'de redactie',
+
+        ];
+        foreach ($users as $lang => $username) {
+            $user = get_user_by('login', $username);
+            if (empty($user)) {
+                return;
+            }
+            WP_CLI::line(sprintf('starting author fix for %s (%s)', $user->display_name, strtoupper($lang)));
+            WP_CLI::runcommand(sprintf(
+                '%s fix %s %d',
+                CmdManager::CORE_CMD_NAMESPACE  . ' ' . static::CMD_NAMESPACE,
+                $lang,
+                $user->ID
+            ));
+        }
+    }
+
+}

--- a/src/Commands/AuthorFix.php
+++ b/src/Commands/AuthorFix.php
@@ -17,7 +17,7 @@ class AuthorFix extends WP_CLI_Command
     }
 
     /**
-     * Prints a greeting.
+     * Sets all posts by default user to be by the user of your choice
      *
      * ## OPTIONS
      *
@@ -59,7 +59,15 @@ class AuthorFix extends WP_CLI_Command
             }
         }
     }
-
+    /**
+     * Sets all posts by default user to be by the editor user for each language
+     * ---
+     *
+     * ## EXAMPLES
+     *
+     *     wp contenteditor author fixAll
+     *
+     */
     public function fixAll()
     {
         $users = [

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/benjaminmedia/willow-base-theme
 Author: Bonnier Publications
 Author URI: https://github.com/benjaminmedia
 Description: Willow Base theme for WordPress - A full WordPress REST API - no frontend at all.
-Version: 1.46.2
+Version: 1.46.3
 License: GNU General Public License
 License URI: https://www.gnu.org/licenses/gpl.html
 */


### PR DESCRIPTION
+ added author clean up WP CLI command
examples:

### fix author on one language only:
`
wp contenthub editor author fix da 3`
lang: da
userId to replace default user with: 3

### fix authors on all languages:
`
wp contenthub editor author fixAll`