### PR TITLE
Bugfix - Fixing a fatal error thrown

### DIFF
--- a/src/Adapters/Wp/Composites/Contents/Types/GalleryAdapter.php
+++ b/src/Adapters/Wp/Composites/Contents/Types/GalleryAdapter.php
@@ -30,7 +30,10 @@ class GalleryAdapter extends AbstractContentAdapter implements GalleryContract
     public function getImages(): Collection
     {
         $collection = collect(array_get($this->acfArray, 'images', []))->map(function ($acfImage) {
-            return new GalleryImage(new GalleryImageAdapter($acfImage));
+            if (is_array($acfImage)) {
+                return new GalleryImage(new GalleryImageAdapter($acfImage));
+            }
+            return null;
         })->reject(function ($image) {
             return is_null($image);
         });

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/benjaminmedia/willow-base-theme
 Author: Bonnier Publications
 Author URI: https://github.com/benjaminmedia
 Description: Willow Base theme for WordPress - A full WordPress REST API - no frontend at all.
-Version: 2.6.1
+Version: 2.6.2
 License: GNU General Public License
 License URI: https://www.gnu.org/licenses/gpl.html
 */


### PR DESCRIPTION
Fixing the following error:
`Uncaught TypeError: Argument 1 passed to Bonnier\Willow\Base\Adapters\Wp\Root\GalleryImageAdapter::__construct() must be of the type array, boolean given, called in /home/forge/api.illvid.dk/web/app/themes/willow-base-theme/src/Adapters/Wp/Composites/Contents/Types/GalleryAdapter.php on line 33 and defined in /home/forge/api.illvid.dk/web/app/themes/willow-base-theme/src/Adapters/Wp/Root/GalleryImageAdapter.php:21`