### PR TITLE
Refactor friday/make generic hyperlink adapter

### DIFF
--- a/src/Adapters/Wp/Pages/Contents/Types/CommercialSpotAdapter.php
+++ b/src/Adapters/Wp/Pages/Contents/Types/CommercialSpotAdapter.php
@@ -2,8 +2,9 @@
 
 namespace Bonnier\Willow\Base\Adapters\Wp\Pages\Contents\Types;
 
+use Bonnier\Willow\Base\Adapters\Wp\Root\LinkAdapter;
 use Bonnier\Willow\Base\Adapters\Wp\Pages\Contents\AbstractContentAdapter;
-use Bonnier\Willow\Base\Adapters\Wp\Pages\Contents\Types\Partials\CommercialSpotHyperlink;
+use Bonnier\Willow\Base\Adapters\Wp\Root\HyperlinkAdapter;
 use Bonnier\Willow\Base\Adapters\Wp\Root\ImageAdapter;
 use Bonnier\Willow\Base\Models\Contracts\Pages\Contents\Types\CommercialSpotContract;
 use Bonnier\Willow\Base\Repositories\WpModelRepository;
@@ -38,10 +39,9 @@ class CommercialSpotAdapter extends AbstractContentAdapter implements Commercial
     public function getLink(): ?HyperlinkContract
     {
         if (($link = array_get($this->acfArray, 'link')) && ($label = array_get($this->acfArray, 'link_label'))) {
-            return new Hyperlink(new CommercialSpotHyperlink(
-                $link,
-                $label
-            ));
+            return new Hyperlink(
+                new HyperlinkAdapter(new LinkAdapter($link, $label))
+            );
         }
 
         return null;

--- a/src/Adapters/Wp/Root/HyperlinkAdapter.php
+++ b/src/Adapters/Wp/Root/HyperlinkAdapter.php
@@ -2,34 +2,40 @@
 
 namespace Bonnier\Willow\Base\Adapters\Wp\Root;
 
+use Bonnier\Willow\Base\Adapters\Wp\Root\LinkAdapter;
 use Bonnier\Willow\Base\Models\Contracts\Root\HyperlinkContract;
+use Bonnier\Willow\Base\Models\Contracts\Widgets\CommercialSpotHyperlinkContract;
 
 class HyperlinkAdapter implements HyperlinkContract
 {
-    protected $image;
+    protected $link;
+    protected $relationship;
+    protected $target;
 
-    public function __construct(ImageAdapter $image)
+    public function __construct(LinkAdapter $link, string $relationship = null, string $target = null)
     {
-        $this->image = $image;
+        $this->link = $link;
+        $this->relationship = $relationship;
+        $this->target = $target;
     }
 
     public function getTitle(): ?string
     {
-        return optional($this->image)->getTitle() ?: null;
+        return $this->link->getTitle() ?: null;
     }
 
     public function getUrl(): ?string
     {
-        return optional($this->image)->getUrl() ?: null;
+        return $this->link->getUrl() ?: null;
     }
 
     public function getRelationship(): ?string
     {
-        return null;
+        return $this->relationship ?: null;
     }
 
     public function getTarget(): ?string
     {
-        return null;
+        return $this->target ?: null;
     }
 }

--- a/src/Adapters/Wp/Root/LinkAdapter.php
+++ b/src/Adapters/Wp/Root/LinkAdapter.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Bonnier\Willow\Base\Adapters\Wp\Root;
+
+use Bonnier\Willow\Base\Models\Contracts\Root\LinkContract;
+
+/**
+ * Class LinkItemAdapter
+ *
+ * @package \Bonnier\Willow\Base\Adapters\Wp
+ */
+class LinkAdapter implements LinkContract
+{
+    protected $url;
+    protected $title;
+    protected $target;
+
+    public function __construct(string $url = null, string $title = null, string $target = null)
+    {
+        $this->url = $url;
+        $this->title = $title;
+        $this->target = $target;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title ?: null;
+    }
+
+    public function getUrl(): ?string
+    {
+        return $this->url ?: null;
+    }
+
+    public function getTarget(): ?string
+    {
+        return $this->target ?: null;
+    }
+}

--- a/src/Models/Base/Composites/Contents/Types/Link.php
+++ b/src/Models/Base/Composites/Contents/Types/Link.php
@@ -3,7 +3,7 @@
 namespace Bonnier\Willow\Base\Models\Base\Composites\Contents\Types;
 
 use Bonnier\Willow\Base\Models\Base\Composites\Contents\AbstractContent;
-use Bonnier\Willow\Base\Models\Contracts\Root\LinkContract;
+use Bonnier\Willow\Base\Models\Contracts\Composites\Contents\Types\LinkContract;
 
 /**
  * Class Link
@@ -17,7 +17,7 @@ class Link extends AbstractContent implements LinkContract
     /**
      * Link constructor.
      *
-     * @param \Bonnier\Willow\Base\Models\Contracts\Root\LinkContract $link
+     * @param Bonnier\Willow\Base\Models\Contracts\Composites\Contents\Types\LinkContract; $link
      */
     public function __construct(LinkContract $link)
     {

--- a/src/Models/Base/Composites/Contents/Types/Link.php
+++ b/src/Models/Base/Composites/Contents/Types/Link.php
@@ -3,7 +3,7 @@
 namespace Bonnier\Willow\Base\Models\Base\Composites\Contents\Types;
 
 use Bonnier\Willow\Base\Models\Base\Composites\Contents\AbstractContent;
-use Bonnier\Willow\Base\Models\Contracts\Composites\Contents\Types\LinkContract;
+use Bonnier\Willow\Base\Models\Contracts\Root\LinkContract;
 
 /**
  * Class Link
@@ -17,7 +17,7 @@ class Link extends AbstractContent implements LinkContract
     /**
      * Link constructor.
      *
-     * @param \Bonnier\Willow\Base\Models\Contracts\Composites\Contents\Types\LinkContract $link
+     * @param \Bonnier\Willow\Base\Models\Contracts\Root\LinkContract $link
      */
     public function __construct(LinkContract $link)
     {

--- a/src/Models/Base/Root/Link.php
+++ b/src/Models/Base/Root/Link.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Bonnier\Willow\Base\Models\Base\Root;
+
+use Bonnier\Willow\Base\Models\Contracts\Composites\Contents\Types\LinkContract;
+
+class Link implements LinkContract
+{
+    protected $hyperlink;
+
+    public function __construct(HyperlinkContract $hyperlink)
+    {
+        $this->hyperlink = $hyperlink;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->hyperlink->getTitle();
+    }
+
+    public function getUrl(): ?string
+    {
+        return $this->hyperlink->getUrl();
+    }
+
+    public function getRelationship(): ?string
+    {
+        return $this->hyperlink->getRelationship();
+    }
+
+    public function getTarget(): ?string
+    {
+        return $this->hyperlink->getTarget();
+    }
+
+    public function getType(): ?string
+    {
+        // TODO: Implement getType() method.
+    }
+
+    public function isLocked(): bool
+    {
+        // TODO: Implement isLocked() method.
+    }
+
+    public function getStickToNext(): bool
+    {
+        // TODO: Implement getStickToNext() method.
+    }
+}

--- a/src/Models/Contracts/Root/LinkContract.php
+++ b/src/Models/Contracts/Root/LinkContract.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Bonnier\Willow\Base\Models\Contracts\Root;
+
+interface LinkContract
+{
+    public function getTitle(): ?string;
+
+    public function getUrl(): ?string;
+
+    public function getTarget(): ?string;
+}

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/benjaminmedia/willow-base-theme
 Author: Bonnier Publications
 Author URI: https://github.com/benjaminmedia
 Description: Willow Base theme for WordPress - A full WordPress REST API - no frontend at all.
-Version: 2.8.0
+Version: 2.9.0
 License: GNU General Public License
 License URI: https://www.gnu.org/licenses/gpl.html
 */


### PR DESCRIPTION
# Refactor-Friday/make generic hyperlink adapter
-  make generic hyperlink adapter
- made a "dumb" link adapter that can make a LinkContract compatible instance from just strings instead of a content object (acfArray)

[link to Refactor Task](https://docs.google.com/spreadsheets/d/1aVKJv9E_68dcapif-HU4YklnOUcCSNP8Zo21ofguCZ8/edit#gid=0&range=A61)