### PR TITLE
Bugfix - Invalid return value used in mapWithKeys

### DIFF
--- a/src/Adapters/Wp/Composites/CompositeAdapter.php
+++ b/src/Adapters/Wp/Composites/CompositeAdapter.php
@@ -367,7 +367,7 @@ class CompositeAdapter extends AbstractWpAdapter implements CompositeContract
             if ($composite instanceof \WP_Post && $composite->post_status === 'publish') {
                 return [$locale => new Translation(new CompositeTranslationAdapter($composite))];
             }
-            return null;
+            return [$locale => null];
         })->reject(function ($translation) {
             return is_null($translation);
         });

--- a/src/Adapters/Wp/Pages/PageAdapter.php
+++ b/src/Adapters/Wp/Pages/PageAdapter.php
@@ -177,7 +177,7 @@ class PageAdapter extends AbstractWpAdapter implements PageContract
             if ($page instanceof WP_Post && $page->post_status === 'publish') {
                 return [$locale => new Translation(new PageTranslationAdapter($page))];
             }
-            return null;
+            return [$locale => null];
         })->reject(function ($translation) {
             return is_null($translation);
         });

--- a/src/Adapters/Wp/Terms/Categories/CategoryAdapter.php
+++ b/src/Adapters/Wp/Terms/Categories/CategoryAdapter.php
@@ -237,7 +237,7 @@ class CategoryAdapter extends AbstractWpAdapter implements CategoryContract
             if ($term instanceof \WP_Term) {
                 return [$locale => new Translation(new CategoryTranslationAdapter($term))];
             }
-            return null;
+            return [$locale => null];
         })->reject(function ($translation) {
             return is_null($translation);
         });

--- a/src/Adapters/Wp/Terms/Tags/TagAdapter.php
+++ b/src/Adapters/Wp/Terms/Tags/TagAdapter.php
@@ -165,7 +165,7 @@ class TagAdapter extends AbstractWpAdapter implements TagContract
             if ($term instanceof WP_Term) {
                 return [$locale => new Translation(new TagTranslationAdapter($term))];
             }
-            return null;
+            return [$locale => null];
         })->reject(function ($translation) {
             return is_null($translation);
         });

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/benjaminmedia/willow-base-theme
 Author: Bonnier Publications
 Author URI: https://github.com/benjaminmedia
 Description: Willow Base theme for WordPress - A full WordPress REST API - no frontend at all.
-Version: 3.8.0
+Version: 3.8.1
 License: GNU General Public License
 License URI: https://www.gnu.org/licenses/gpl.html
 */


### PR DESCRIPTION
The mapWithKeys callback, must ALWAYS return an array. If it returns null, it throws a warning.