### PR TITLE
HIS-47 - Bugfix tag counting

### DIFF
--- a/src/Controllers/App/SitemapController.php
+++ b/src/Controllers/App/SitemapController.php
@@ -218,7 +218,7 @@ class SitemapController extends WP_REST_Controller
     private function getExcludedPostTagsIds(string $taxonomy)
     {
         if ($taxonomy === 'post_tag') {
-            return collect(get_terms($taxonomy))->reject(function (\WP_Term $tag) {
+            return collect(get_terms($taxonomy, ['hide_empty' => false]))->reject(function (\WP_Term $tag) {
                 return $tag->count >= 5;
             })->pluck('term_id')->toArray();
         }

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/benjaminmedia/willow-base-theme
 Author: Bonnier Publications
 Author URI: https://github.com/benjaminmedia
 Description: Willow Base theme for WordPress - A full WordPress REST API - no frontend at all.
-Version: 3.12.0
+Version: 3.12.1
 License: GNU General Public License
 License URI: https://www.gnu.org/licenses/gpl.html
 */


### PR DESCRIPTION
When calculating the tags to be excluded, all empty tags should be part of the calculation, otherwise all empty tags will NOT be excluded.