### PR TITLE
HIS-51 - Trailings slash on tag pages should redirect

### DIFF
--- a/src/Controllers/App/RouteController.php
+++ b/src/Controllers/App/RouteController.php
@@ -223,7 +223,7 @@ class RouteController extends BaseController
         }
 
         // Route resolving for tag pages
-        if (preg_match('#/?tags/([^/]+)$#', $path, $match)) {
+        if (preg_match('#/?tags/([^/]+)/?$#', $path, $match)) {
             $slug = $match[1];
             if ($tag = get_term_by('slug', $slug, 'post_tag')) {
                 return $tag;

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/benjaminmedia/willow-base-theme
 Author: Bonnier Publications
 Author URI: https://github.com/benjaminmedia
 Description: Willow Base theme for WordPress - A full WordPress REST API - no frontend at all.
-Version: 3.22.0
+Version: 3.22.1
 License: GNU General Public License
 License URI: https://www.gnu.org/licenses/gpl.html
 */


### PR DESCRIPTION
Updating `preg_match` to allow for an optional trailing slash. This will then be redirected by the `shouldPathRedirect` method.