### PR TITLE
Bugfix - WPModelRepository always returns WP_Post or null

### DIFF
--- a/src/Repositories/WpModelRepository.php
+++ b/src/Repositories/WpModelRepository.php
@@ -57,7 +57,7 @@ class WpModelRepository
     /**
      * @param int|array|\WP_Post $wpPost
      *
-     * @return array|\WP_Post|null
+     * @return \WP_Post|null
      */
     public function getPost($wpPost)
     {
@@ -66,9 +66,13 @@ class WpModelRepository
             return null;
         }
 
-        if ($wpPost instanceof \WP_Post || is_array($wpPost)) {
+        if ($wpPost instanceof \WP_Post) {
             $this->posts->put($postId, $wpPost);
             return $wpPost;
+        } elseif (is_array($wpPost) && array_key_exists('ID', $wpPost)) {
+            $post = new \WP_Post((object)$wpPost);
+            $this->posts->put($postId, $post);
+            return $post;
         }
 
         if (($post = $this->posts->get($postId, false)) && $post !== false) {

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/benjaminmedia/willow-base-theme
 Author: Bonnier Publications
 Author URI: https://github.com/benjaminmedia
 Description: Willow Base theme for WordPress - A full WordPress REST API - no frontend at all.
-Version: 3.26.0
+Version: 3.26.1
 License: GNU General Public License
 License URI: https://www.gnu.org/licenses/gpl.html
 */


### PR DESCRIPTION
Instead of sometimes returning an array, `WPModelRepository->getPost()` will now always return a WP_Post object or null.