### PR TITLE
WILL-1765 - HTML encoded special characters in titles

### DIFF
--- a/src/Adapters/Wp/Terms/Categories/CategoryAdapter.php
+++ b/src/Adapters/Wp/Terms/Categories/CategoryAdapter.php
@@ -73,7 +73,10 @@ class CategoryAdapter extends AbstractWpAdapter implements CategoryContract
 
     public function getName(): ?string
     {
-        return data_get($this->wpModel, 'name') ?: null;
+        if ($name = data_get($this->wpModel, 'name')) {
+            return htmlspecialchars_decode($name);
+        }
+        return null;
     }
 
     public function getChildren(): ?Collection

--- a/src/Adapters/Wp/Terms/Categories/CategoryTeaserAdapter.php
+++ b/src/Adapters/Wp/Terms/Categories/CategoryTeaserAdapter.php
@@ -20,7 +20,11 @@ class CategoryTeaserAdapter extends AbstractTeaserAdapter
 
     public function getTitle(): ?string
     {
-        return data_get($this->meta, 'meta_title.0') ?: null;
+        if ($title = data_get($this->meta, 'meta_title.0')) {
+            return htmlspecialchars_decode($title);
+        }
+
+        return null;
     }
 
     public function getImage(): ?ImageContract

--- a/src/Adapters/Wp/Terms/Categories/CategoryTeaserAdapter.php
+++ b/src/Adapters/Wp/Terms/Categories/CategoryTeaserAdapter.php
@@ -23,7 +23,6 @@ class CategoryTeaserAdapter extends AbstractTeaserAdapter
         if ($title = data_get($this->meta, 'meta_title.0')) {
             return htmlspecialchars_decode($title);
         }
-
         return null;
     }
 

--- a/src/Adapters/Wp/Terms/Categories/CategoryTranslationAdapter.php
+++ b/src/Adapters/Wp/Terms/Categories/CategoryTranslationAdapter.php
@@ -25,7 +25,11 @@ class CategoryTranslationAdapter implements TranslationContract
 
     public function getTitle(): ?string
     {
-        return data_get($this->category, 'name') ?: null;
+        if ($title = data_get($this->category, 'name')) {
+            return htmlspecialchars_decode($title);
+        }
+
+        return null;
     }
 
     public function getLink(): ?string

--- a/src/Adapters/Wp/Terms/Categories/CategoryTranslationAdapter.php
+++ b/src/Adapters/Wp/Terms/Categories/CategoryTranslationAdapter.php
@@ -28,7 +28,6 @@ class CategoryTranslationAdapter implements TranslationContract
         if ($title = data_get($this->category, 'name')) {
             return htmlspecialchars_decode($title);
         }
-
         return null;
     }
 

--- a/src/Adapters/Wp/Terms/Tags/TagAdapter.php
+++ b/src/Adapters/Wp/Terms/Tags/TagAdapter.php
@@ -37,7 +37,10 @@ class TagAdapter extends AbstractWpAdapter implements TagContract
 
     public function getName(): ?string
     {
-        return data_get($this->wpModel, 'name') ?: null;
+        if ($name = data_get($this->wpModel, 'name')) {
+            return htmlspecialchars_decode($name);
+        }
+        return null;
     }
 
     public function getTitle(): ?string

--- a/src/Adapters/Wp/Terms/Tags/TagTeaserAdapter.php
+++ b/src/Adapters/Wp/Terms/Tags/TagTeaserAdapter.php
@@ -18,7 +18,10 @@ class TagTeaserAdapter extends AbstractTeaserAdapter
 
     public function getTitle(): ?string
     {
-        return data_get($this->meta, 'meta_title.' . LanguageProvider::getCurrentLanguage()) ?: null;
+        if ($title = data_get($this->meta, 'meta_title.' . LanguageProvider::getCurrentLanguage())) {
+            return htmlspecialchars_decode($title);
+        }
+        return null;
     }
 
     public function getImage(): ?ImageContract

--- a/src/Adapters/Wp/Terms/Tags/TagTranslationAdapter.php
+++ b/src/Adapters/Wp/Terms/Tags/TagTranslationAdapter.php
@@ -25,7 +25,10 @@ class TagTranslationAdapter implements TranslationContract
 
     public function getTitle(): ?string
     {
-        return data_get($this->tag, 'name') ?: null;
+        if ($title = data_get($this->tag, 'name')) {
+            return htmlspecialchars_decode($title);
+        }
+        return null;
     }
 
     public function getLink(): ?string

--- a/src/Adapters/Wp/Terms/Vocabulary/VocabularyAdapter.php
+++ b/src/Adapters/Wp/Terms/Vocabulary/VocabularyAdapter.php
@@ -31,7 +31,10 @@ class VocabularyAdapter implements VocabularyContract
 
     public function getName(): ?string
     {
-        return data_get($this->vocabulary, 'name') ?: null;
+        if ($name = data_get($this->vocabulary, 'name')) {
+            return htmlspecialchars_decode($name);
+        }
+        return null;
     }
 
     public function getMachineName(): ?string

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/benjaminmedia/willow-base-theme
 Author: Bonnier Publications
 Author URI: https://github.com/benjaminmedia
 Description: Willow Base theme for WordPress - A full WordPress REST API - no frontend at all.
-Version: 3.31.1
+Version: 3.31.2
 License: GNU General Public License
 License URI: https://www.gnu.org/licenses/gpl.html
 */


### PR DESCRIPTION
Wrapping titles and names from terms in htmlspecialchars_decode, to ensure that ampersands are outputtet in plaintext, instead of being HTML encoded.