### PR TITLE
WILL-717 - Support drafted pages in route resolver

### DIFF
--- a/src/Controllers/App/RouteController.php
+++ b/src/Controllers/App/RouteController.php
@@ -196,15 +196,25 @@ class RouteController extends BaseController
 
         // Route resolving for previewing article drafts
         if (
-            ($queryParams['preview'] ?? false) &&
-            ($queryParams['post_type'] ?? false) &&
-            ($queryParams['p'] ?? false)
+            ($queryParams['preview'] ?? false)
         ) {
-            $posts =  get_posts([
-                'post_type' => $queryParams['post_type'],
-                'include' => $queryParams['p'], // Wordpress way of saying give me the content that match id
-                'post_status' => self::STATUS_DRAFT,
-            ]);
+            $posts = [];
+            if (
+                ($queryParams['post_type'] ?? false) &&
+                ($queryParams['p'] ?? false)
+            ) {
+                $posts = get_posts([
+                    'post_type' => $queryParams['post_type'],
+                    'include' => $queryParams['p'], // Wordpress way of saying give me the content that match id
+                    'post_status' => self::STATUS_DRAFT,
+                ]);
+            } else if ($queryParams['page_id'] ?? false) {
+                $posts = get_posts([
+                    'post_type' => 'page',
+                    'include' => $queryParams['page_id'],
+                    'post_status' => self::STATUS_DRAFT
+                ]);
+            }
             if (count($posts)) {
                 return $posts[0];
             }

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/benjaminmedia/willow-base-theme
 Author: Bonnier Publications
 Author URI: https://github.com/benjaminmedia
 Description: Willow Base theme for WordPress - A full WordPress REST API - no frontend at all.
-Version: 3.32.2
+Version: 3.32.4
 License: GNU General Public License
 License URI: https://www.gnu.org/licenses/gpl.html
 */


### PR DESCRIPTION
Drafted pages has a slightly different query parameter structure to contenthub composites, which has now been supported to return drafted pages as well as drafted composites.