### PR TITLE
WILL-717 - Making page drafts public

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -7,6 +7,8 @@ add_action('init', function () {
 });
 add_action('admin_menu', [Bootstrap::class, 'loadAdminMenu']);
 
+add_filter('register_post_type_args', [Bootstrap::class, 'registerPageRestController'], 10, 2);
+
 remove_action('template_redirect', 'redirect_canonical');
 
 // Redirect all requests to index.php so the Vue app is loaded and 404s aren't thrown

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -7,6 +7,7 @@ use Bonnier\Willow\Base\Commands\CommandBootstrap;
 use Bonnier\Willow\Base\Controllers\Admin\NotFoundSettingsController;
 use Bonnier\Willow\Base\Controllers\App\AppControllerBootstrap;
 use Bonnier\Willow\Base\Controllers\Formatters\ControllerBootstrap;
+use Bonnier\Willow\Base\Controllers\Root\PageController;
 use Bonnier\Willow\Base\Database\DB;
 use Bonnier\Willow\Base\Database\Migrations\Migrate;
 use Bonnier\Willow\Base\Repositories\NotFoundRepository;
@@ -87,6 +88,14 @@ class Bootstrap
         $request = Request::createFromGlobals();
         self::$notFoundSettingsController = new NotFoundSettingsController($request);
         self::$notFoundSettingsController->handlePost();
+    }
+
+    public static function registerPageRestController(array $args, string $postType)
+    {
+        if ($postType === 'page') {
+            $args['rest_controller_class'] = PageController::class;
+        }
+        return $args;
     }
 
     public static function removeNotFoundRedirects(Redirect $redirect)

--- a/src/Controllers/Root/PageController.php
+++ b/src/Controllers/Root/PageController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Bonnier\Willow\Base\Controllers\Root;
+
+class PageController extends \WP_REST_Posts_Controller
+{
+    public function check_read_permission($post)
+    {
+        return true;
+    }
+}

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/benjaminmedia/willow-base-theme
 Author: Bonnier Publications
 Author URI: https://github.com/benjaminmedia
 Description: Willow Base theme for WordPress - A full WordPress REST API - no frontend at all.
-Version: 3.32.5
+Version: 3.32.6
 License: GNU General Public License
 License URI: https://www.gnu.org/licenses/gpl.html
 */


### PR DESCRIPTION
In order for editors to view drafted pages, we needed to overwrite the default REST controller and ensure the `check_read_permission` would return true.