### PR TITLE
Feature: disable other options in select box

### DIFF
--- a/assets/js/acf/fields/taxonomy-fields.js
+++ b/assets/js/acf/fields/taxonomy-fields.js
@@ -1,18 +1,21 @@
 (function () {
     function disableElements(selector) {
+        $(selector).attr('readonly', 'readonly');
+    }
+    function disableSelectOptions(selector) {
         document.querySelectorAll(selector).forEach(function (ele){
-            ele.disabled = true;
+            ele.find($('option:not(:selected)').attr('disabled', true));
         });
     }
     document.addEventListener("DOMContentLoaded", function(event) {
         // Disable fields on: Edit Tag
         disableElements('body.taxonomy-post_tag form[name=edittag] table.form-table:first-of-type input');
         disableElements('body.taxonomy-post_tag form[name=edittag] table.form-table:first-of-type textarea');
-        disableElements('body.taxonomy-post_tag form[name=edittag] table.form-table:first-of-type select');
+        disableSelectOptions('body.taxonomy-post_tag form[name=edittag] table.form-table:first-of-type select');
 
         // Disable fields on: Edit Category
         disableElements('body.taxonomy-category form[name=edittag] table.form-table:first-of-type input');
         disableElements('body.taxonomy-category form[name=edittag] table.form-table:first-of-type textarea');
-        disableElements('body.taxonomy-category form[name=edittag] table.form-table:first-of-type select');
+        disableSelectOptions('body.taxonomy-category form[name=edittag] table.form-table:first-of-type select');
     });
 })();

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/benjaminmedia/willow-base-theme
 Author: Bonnier Publications
 Author URI: https://github.com/benjaminmedia
 Description: Willow Base theme for WordPress - A full WordPress REST API - no frontend at all.
-Version: 4.33.0
+Version: 4.34.0
 License: GNU General Public License
 License URI: https://www.gnu.org/licenses/gpl.html
 */


### PR DESCRIPTION
Categories can not be updated as the select boxes was disabled an alternative to this is to disable other options than the select itself.

also used readonly instead of disabled as it is less intrusive.