### PR TITLE
Chore: remove role filtering on author overview

### DIFF
--- a/src/Models/ACF/Page/PageFieldGroup.php
+++ b/src/Models/ACF/Page/PageFieldGroup.php
@@ -257,7 +257,6 @@ class PageFieldGroup
         $userField = (new UserField('field_5ffd94425dd8c'))
             ->setLabel('Authors')
             ->setName('authors')
-            ->setRole('author')
             ->setRequired(true)
             ->setMultiple(true)
             ->setInstructions('Author overview will only display public authors, even thou you can select non public ones. The order of the authors will determine the order on the overview page.');

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/benjaminmedia/willow-base-theme
 Author: Bonnier Publications
 Author URI: https://github.com/benjaminmedia
 Description: Willow Base theme for WordPress - A full WordPress REST API - no frontend at all.
-Version: 4.38.1
+Version: 4.38.3
 License: GNU General Public License
 License URI: https://www.gnu.org/licenses/gpl.html
 */


### PR DESCRIPTION
The role filtering will cause more problems than actually helping, during i was setting a test page for costume up, was not a pleasant experience having this prefiltered.