### PR TITLE
Chore: strip api respect new url format

### DIFF
--- a/src/Traits/UrlTrait.php
+++ b/src/Traits/UrlTrait.php
@@ -38,7 +38,8 @@ trait UrlTrait
             $parsedUrl = parse_url($url, PHP_URL_HOST);
             $parsedHomeUrl = parse_url($language->home_url, PHP_URL_HOST);
             if(stristr($parsedUrl, $parsedHomeUrl) !== false) {
-                return preg_replace('#://(api|native-api|admin)\.#', '://', $url);
+                $replace = preg_replace('#://(admin-|api-|native-api-)#', '://', $url);
+                return preg_replace('#://(api|native-api|admin)\.#', '://', $replace);
             }
         }
         return $url;

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/benjaminmedia/willow-base-theme
 Author: Bonnier Publications
 Author URI: https://github.com/benjaminmedia
 Description: Willow Base theme for WordPress - A full WordPress REST API - no frontend at all.
-Version: 4.42.6
+Version: 4.42.7
 License: GNU General Public License
 License URI: https://www.gnu.org/licenses/gpl.html
 */


### PR DESCRIPTION
When we strip canonical urls we expect the format to be api.beta.illvid.dk. Due to cloudflare we have changed to the format api-beta.illvid.dk therefor the strip function needs to be updated.