### PR TITLE
IFD-272/Remove-images-from-File-widget-on-IFORM

### DIFF
--- a/src/ACF/Brands/Brand.php
+++ b/src/ACF/Brands/Brand.php
@@ -97,14 +97,6 @@ abstract class Brand implements BrandInterface
         return $layout->setSubFields($fields);
     }
 
-    public static function removeImageRepeaterField(ACFLayout $layout)
-    {
-        $fields = array_filter($layout->getSubFields(), function (ACFField $field) {
-            return $field->getName() !== 'images';
-        });
-        return $layout->setSubFields($fields);
-    }
-
     protected static function removeVideoUrlFromImageWidget()
     {
         $imageWidget = CompositeFieldGroup::getImageWidget();
@@ -139,12 +131,6 @@ abstract class Brand implements BrandInterface
     {
         $galleryWidget = CompositeFieldGroup::getGalleryWidget();
         add_filter(sprintf('willow/acf/layout=%s', $galleryWidget->getKey()), [__CLASS__, 'removeVideoUrlField']);
-    }
-
-    protected static function removeImageRepeaterFromFile(): void
-    {
-        $fileWidget = CompositeFieldGroup::getFileWidget();
-        add_filter(sprintf('willow/acf/layout=%s', $fileWidget->getKey()), [__CLASS__, 'removeImageRepeaterField']);
     }
 
     protected static function removeVideoUrlFromTeaserImages()

--- a/src/ACF/Brands/Brand.php
+++ b/src/ACF/Brands/Brand.php
@@ -97,6 +97,14 @@ abstract class Brand implements BrandInterface
         return $layout->setSubFields($fields);
     }
 
+    public static function removeImageRepeaterField(ACFLayout $layout)
+    {
+        $fields = array_filter($layout->getSubFields(), function (ACFField $field) {
+            return $field->getName() !== 'images';
+        });
+        return $layout->setSubFields($fields);
+    }
+
     protected static function removeVideoUrlFromImageWidget()
     {
         $imageWidget = CompositeFieldGroup::getImageWidget();
@@ -131,6 +139,12 @@ abstract class Brand implements BrandInterface
     {
         $galleryWidget = CompositeFieldGroup::getGalleryWidget();
         add_filter(sprintf('willow/acf/layout=%s', $galleryWidget->getKey()), [__CLASS__, 'removeVideoUrlField']);
+    }
+
+    protected static function removeImageRepeaterFromFile(): void
+    {
+        $fileWidget = CompositeFieldGroup::getFileWidget();
+        add_filter(sprintf('willow/acf/layout=%s', $fileWidget->getKey()), [__CLASS__, 'removeImageRepeaterField']);
     }
 
     protected static function removeVideoUrlFromTeaserImages()

--- a/src/ACF/Brands/IFO.php
+++ b/src/ACF/Brands/IFO.php
@@ -20,6 +20,7 @@ class IFO extends Brand
         self::removeVideoUrlFromTeaserImages();
         self::removeImageFromInfoboxWidget();
         self::removeSortByEditorialTypeFromTeaserListPageWidget();
+        self::removeImageRepeaterFromFile();
 
         self::removeInventoryWidget();
         self::removeAudioWidget();

--- a/src/ACF/Brands/IFO.php
+++ b/src/ACF/Brands/IFO.php
@@ -5,7 +5,9 @@ namespace Bonnier\Willow\Base\ACF\Brands;
 use Bonnier\Willow\Base\Models\ACF\ACFField;
 use Bonnier\Willow\Base\Models\ACF\ACFLayout;
 use Bonnier\Willow\Base\Models\ACF\Composite\CompositeFieldGroup;
+use Bonnier\Willow\Base\Models\ACF\Fields\ImageField;
 use Bonnier\Willow\Base\Models\ACF\Fields\RadioField;
+use Bonnier\Willow\Base\Models\ACF\Fields\RepeaterField;
 use Bonnier\Willow\Base\Models\ACF\Fields\TrueFalseField;
 use Bonnier\Willow\Base\Models\ACF\Page\PageFieldGroup;
 
@@ -20,7 +22,6 @@ class IFO extends Brand
         self::removeVideoUrlFromTeaserImages();
         self::removeImageFromInfoboxWidget();
         self::removeSortByEditorialTypeFromTeaserListPageWidget();
-        self::removeImageRepeaterFromFile();
 
         self::removeInventoryWidget();
         self::removeAudioWidget();
@@ -51,6 +52,9 @@ class IFO extends Brand
 
         $videoWidget = CompositeFieldGroup::getVideoWidget();
         add_filter(sprintf('willow/acf/layout=%s', $videoWidget->getKey()), [__CLASS__, 'setIncludeIntroVideoDefaultTrue']);
+
+        $fileWidget = CompositeFieldGroup::getFileWidget();
+        add_filter(sprintf('willow/acf/layout=%s', $fileWidget->getKey()), [__CLASS__, 'removeRequiredFromFileWidgetImages']);
     }
 
     public static function setTeaserListDisplayHints(ACFLayout $teaserList)
@@ -152,6 +156,27 @@ class IFO extends Brand
             ->setReturnFormat(ACFField::RETURN_VALUE);
 
         return $associatedComposite->addSubField($displayHint);
+    }
+
+    public static function removeRequiredFromFileWidgetImages(ACFLayout $fileWidget)
+    {
+        $images = new RepeaterField('field_5921e5a83f4ea');
+        $images->setLabel('Images')
+            ->setName('images')
+            ->setRequired(false)
+            ->setLayout('table')
+            ->setButtonLabel('Add Image');
+
+        $image = new ImageField('field_5921e94c3f4eb');
+        $image->setLabel('File')
+            ->setName('file')
+            ->setRequired(false)
+            ->setReturnFormat(ACFField::RETURN_ARRAY)
+            ->setPreviewSize(ImageField::PREVIEW_MEDIUM);
+
+        $images->addSubField($image);
+
+        return $fileWidget->addSubField($images);
     }
 
     public static function removeParagraphListCollapsible(ACFLayout $layout)

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/benjaminmedia/willow-base-theme
 Author: Bonnier Publications
 Author URI: https://github.com/benjaminmedia
 Description: Willow Base theme for WordPress - A full WordPress REST API - no frontend at all.
-Version: 4.43.5
+Version: 4.43.6
 License: GNU General Public License
 License URI: https://www.gnu.org/licenses/gpl.html
 */


### PR DESCRIPTION
It is only the REQUIRED option for the images repeater + image that should be removed.

Else we cant import/migrate data that does not have images.