### PR TITLE
IFD-234/Add-taxonomy-choices-to-teaser-list

### DIFF
--- a/src/ACF/Brands/BOB.php
+++ b/src/ACF/Brands/BOB.php
@@ -21,7 +21,7 @@ class BOB extends Brand
         self::removeIncludeIntroVideoFromVideoWidget();
         self::removeThemeFromTeaserListPageWidget();
         self::removeSortByEditorialTypeFromTeaserListPageWidget();
-        self::removeAdvancedSortByFieldsFromTeaserListPageWidget();
+        self::removeAdvancedCustomSortByFieldsFromTeaserListPageWidget();
         self::removeTitleFromAssociatedCompositesWidget();
         self::removeDisplayHintFromAssociatedCompositesWidget();
         self::removeDurationFromVideoWidget();

--- a/src/ACF/Brands/BOB.php
+++ b/src/ACF/Brands/BOB.php
@@ -21,6 +21,7 @@ class BOB extends Brand
         self::removeIncludeIntroVideoFromVideoWidget();
         self::removeThemeFromTeaserListPageWidget();
         self::removeSortByEditorialTypeFromTeaserListPageWidget();
+        self::removeAdvancedSortByFieldsFromTeaserListPageWidget();
         self::removeTitleFromAssociatedCompositesWidget();
         self::removeDisplayHintFromAssociatedCompositesWidget();
         self::removeDurationFromVideoWidget();

--- a/src/ACF/Brands/Brand.php
+++ b/src/ACF/Brands/Brand.php
@@ -4,6 +4,7 @@
 namespace Bonnier\Willow\Base\ACF\Brands;
 
 
+use Bonnier\Willow\Base\Helpers\AcfName;
 use Bonnier\Willow\Base\Models\ACF\ACFField;
 use Bonnier\Willow\Base\Models\ACF\ACFGroup;
 use Bonnier\Willow\Base\Models\ACF\ACFLayout;
@@ -144,6 +145,18 @@ abstract class Brand implements BrandInterface
         return $layout->setSubFields($fields);
     }
 
+    public static function removeAdvancedSortByFields(ACFLayout $layout)
+    {
+        $fields = array_filter($layout->getSubFields(), function (ACFField $field) {
+            return in_array($field->getName(), [
+                AcfName::FIELD_INCLUDE_CATEGORY_CHILDREN,
+                AcfName::FIELD_CATEGORY_TAG_RELATION,
+                AcfName::FIELD_TAG_OPERATION,
+            ]);
+        });
+        return $layout->setSubFields($fields);
+    }
+
     protected static function removeVideoUrlFromImageWidget()
     {
         $imageWidget = CompositeFieldGroup::getImageWidget();
@@ -226,6 +239,12 @@ abstract class Brand implements BrandInterface
     {
         $associatedComposites = CompositeFieldGroup::getAssociatedCompositeWidget();
         add_filter(sprintf('willow/acf/layout=%s', $associatedComposites->getKey()), [__CLASS__, 'removeDisplayHintField']);
+    }
+
+    protected static function removeAdvancedSortByFieldsFromTeaserListPageWidget()
+    {
+        $teaserListWidget =  PageFieldGroup::getTeaserListLayout();
+        add_filter(sprintf('willow/acf/layout=%s', $teaserListWidget->getKey()), [__CLASS__, 'removeAdvancedSortByFields']);
     }
 
     protected static function removeLanguageTitlesFromUserFieldGroup()

--- a/src/ACF/Brands/Brand.php
+++ b/src/ACF/Brands/Brand.php
@@ -149,10 +149,10 @@ abstract class Brand implements BrandInterface
     {
         $fields = array_filter($layout->getSubFields(), function (ACFField $field) {
             return in_array($field->getName(), [
-                AcfName::FIELD_INCLUDE_CATEGORY_CHILDREN,
-                AcfName::FIELD_CATEGORY_TAG_RELATION,
-                AcfName::FIELD_CATEGORY_OPERATOR,
-                AcfName::FIELD_TAG_OPERATOR,
+                AcfName::FIELD_INCLUDE_CHILDREN,
+                AcfName::FIELD_CATEGORIES_TAGS_RELATION,
+                AcfName::FIELD_CATEGORIES_OPERATOR,
+                AcfName::FIELD_TAGS_OPERATOR,
             ]);
         });
         return $layout->setSubFields($fields);

--- a/src/ACF/Brands/Brand.php
+++ b/src/ACF/Brands/Brand.php
@@ -151,6 +151,7 @@ abstract class Brand implements BrandInterface
             return in_array($field->getName(), [
                 AcfName::FIELD_INCLUDE_CATEGORY_CHILDREN,
                 AcfName::FIELD_CATEGORY_TAG_RELATION,
+                AcfName::FIELD_CATEGORY_OPERATION,
                 AcfName::FIELD_TAG_OPERATION,
             ]);
         });

--- a/src/ACF/Brands/Brand.php
+++ b/src/ACF/Brands/Brand.php
@@ -145,7 +145,7 @@ abstract class Brand implements BrandInterface
         return $layout->setSubFields($fields);
     }
 
-    public static function removeAdvancedSortByFields(ACFLayout $layout)
+    public static function removeAdvancedCustomSortByFields(ACFLayout $layout)
     {
         $fields = array_filter($layout->getSubFields(), function (ACFField $field) {
             return in_array($field->getName(), [
@@ -242,10 +242,10 @@ abstract class Brand implements BrandInterface
         add_filter(sprintf('willow/acf/layout=%s', $associatedComposites->getKey()), [__CLASS__, 'removeDisplayHintField']);
     }
 
-    protected static function removeAdvancedSortByFieldsFromTeaserListPageWidget()
+    protected static function removeAdvancedCustomSortByFieldsFromTeaserListPageWidget()
     {
         $teaserListWidget =  PageFieldGroup::getTeaserListLayout();
-        add_filter(sprintf('willow/acf/layout=%s', $teaserListWidget->getKey()), [__CLASS__, 'removeAdvancedSortByFields']);
+        add_filter(sprintf('willow/acf/layout=%s', $teaserListWidget->getKey()), [__CLASS__, 'removeAdvancedCustomSortByFields']);
     }
 
     protected static function removeLanguageTitlesFromUserFieldGroup()

--- a/src/ACF/Brands/Brand.php
+++ b/src/ACF/Brands/Brand.php
@@ -151,8 +151,8 @@ abstract class Brand implements BrandInterface
             return in_array($field->getName(), [
                 AcfName::FIELD_INCLUDE_CATEGORY_CHILDREN,
                 AcfName::FIELD_CATEGORY_TAG_RELATION,
-                AcfName::FIELD_CATEGORY_OPERATION,
-                AcfName::FIELD_TAG_OPERATION,
+                AcfName::FIELD_CATEGORY_OPERATOR,
+                AcfName::FIELD_TAG_OPERATOR,
             ]);
         });
         return $layout->setSubFields($fields);

--- a/src/ACF/Brands/COS.php
+++ b/src/ACF/Brands/COS.php
@@ -21,7 +21,7 @@ class COS extends Brand
         self::removeChapterItemsFromVideoWidget();
         self::removeThemeFromTeaserListPageWidget();
         self::removeSortByEditorialTypeFromTeaserListPageWidget();
-        self::removeAdvancedSortByFieldsFromTeaserListPageWidget();
+        self::removeAdvancedCustomSortByFieldsFromTeaserListPageWidget();
         self::removeTitleFromAssociatedCompositesWidget();
         self::removeDisplayHintFromAssociatedCompositesWidget();
         self::removeDurationFromVideoWidget();

--- a/src/ACF/Brands/COS.php
+++ b/src/ACF/Brands/COS.php
@@ -21,6 +21,7 @@ class COS extends Brand
         self::removeChapterItemsFromVideoWidget();
         self::removeThemeFromTeaserListPageWidget();
         self::removeSortByEditorialTypeFromTeaserListPageWidget();
+        self::removeAdvancedSortByFieldsFromTeaserListPageWidget();
         self::removeTitleFromAssociatedCompositesWidget();
         self::removeDisplayHintFromAssociatedCompositesWidget();
         self::removeDurationFromVideoWidget();

--- a/src/ACF/Brands/GDS.php
+++ b/src/ACF/Brands/GDS.php
@@ -21,7 +21,7 @@ class GDS extends Brand
         self::removeIncludeIntroVideoFromVideoWidget();
         self::removeChapterItemsFromVideoWidget();
         self::removeThemeFromTeaserListPageWidget();
-        self::removeAdvancedSortByFieldsFromTeaserListPageWidget();
+        self::removeAdvancedCustomSortByFieldsFromTeaserListPageWidget();
         self::removeTitleFromAssociatedCompositesWidget();
         self::removeDisplayHintFromAssociatedCompositesWidget();
         self::removeDurationFromVideoWidget();

--- a/src/ACF/Brands/GDS.php
+++ b/src/ACF/Brands/GDS.php
@@ -21,6 +21,7 @@ class GDS extends Brand
         self::removeIncludeIntroVideoFromVideoWidget();
         self::removeChapterItemsFromVideoWidget();
         self::removeThemeFromTeaserListPageWidget();
+        self::removeAdvancedSortByFieldsFromTeaserListPageWidget();
         self::removeTitleFromAssociatedCompositesWidget();
         self::removeDisplayHintFromAssociatedCompositesWidget();
         self::removeDurationFromVideoWidget();

--- a/src/ACF/Brands/HIS.php
+++ b/src/ACF/Brands/HIS.php
@@ -22,7 +22,7 @@ class HIS extends Brand
         self::removeChapterItemsFromVideoWidget();
         self::removeThemeFromTeaserListPageWidget();
         self::removeSortByEditorialTypeFromTeaserListPageWidget();
-        self::removeAdvancedSortByFieldsFromTeaserListPageWidget();
+        self::removeAdvancedCustomSortByFieldsFromTeaserListPageWidget();
         self::removeTitleFromAssociatedCompositesWidget();
         self::removeDisplayHintFromAssociatedCompositesWidget();
         self::removeDurationFromVideoWidget();

--- a/src/ACF/Brands/HIS.php
+++ b/src/ACF/Brands/HIS.php
@@ -22,6 +22,7 @@ class HIS extends Brand
         self::removeChapterItemsFromVideoWidget();
         self::removeThemeFromTeaserListPageWidget();
         self::removeSortByEditorialTypeFromTeaserListPageWidget();
+        self::removeAdvancedSortByFieldsFromTeaserListPageWidget();
         self::removeTitleFromAssociatedCompositesWidget();
         self::removeDisplayHintFromAssociatedCompositesWidget();
         self::removeDurationFromVideoWidget();

--- a/src/ACF/Brands/IFO.php
+++ b/src/ACF/Brands/IFO.php
@@ -38,6 +38,7 @@ class IFO extends Brand
 
         $teaserListWidget =  PageFieldGroup::getTeaserListLayout();
         add_filter(sprintf('willow/acf/layout=%s', $teaserListWidget->getKey()), [__CLASS__, 'setTeaserListDisplayHints']);
+        add_filter(sprintf('willow/acf/layout=%s', $teaserListWidget->getKey()), [__CLASS__, 'setTeaserListMultiCategoryField']);
         add_filter(sprintf('willow/acf/layout=%s', $teaserListWidget->getKey()), [__CLASS__, 'setTeaserListMultiTagField']);
 
         $galleryField = CompositeFieldGroup::getGalleryWidget();

--- a/src/ACF/Brands/ILL.php
+++ b/src/ACF/Brands/ILL.php
@@ -18,7 +18,7 @@ class ILL extends Brand
         self::removeChapterItemsFromVideoWidget();
         self::removeThemeFromTeaserListPageWidget();
         self::removeSortByEditorialTypeFromTeaserListPageWidget();
-        self::removeAdvancedSortByFieldsFromTeaserListPageWidget();
+        self::removeAdvancedCustomSortByFieldsFromTeaserListPageWidget();
         self::removeTitleFromAssociatedCompositesWidget();
         self::removeDisplayHintFromAssociatedCompositesWidget();
         self::removeDurationFromVideoWidget();

--- a/src/ACF/Brands/ILL.php
+++ b/src/ACF/Brands/ILL.php
@@ -18,6 +18,7 @@ class ILL extends Brand
         self::removeChapterItemsFromVideoWidget();
         self::removeThemeFromTeaserListPageWidget();
         self::removeSortByEditorialTypeFromTeaserListPageWidget();
+        self::removeAdvancedSortByFieldsFromTeaserListPageWidget();
         self::removeTitleFromAssociatedCompositesWidget();
         self::removeDisplayHintFromAssociatedCompositesWidget();
         self::removeDurationFromVideoWidget();

--- a/src/ACF/Brands/VOL.php
+++ b/src/ACF/Brands/VOL.php
@@ -26,7 +26,7 @@ class VOL extends Brand
         self::removeChapterItemsFromVideoWidget();
         self::removeThemeFromTeaserListPageWidget();
         self::removeSortByEditorialTypeFromTeaserListPageWidget();
-        self::removeAdvancedSortByFieldsFromTeaserListPageWidget();
+        self::removeAdvancedCustomSortByFieldsFromTeaserListPageWidget();
         self::removeTitleFromAssociatedCompositesWidget();
         self::removeDisplayHintFromAssociatedCompositesWidget();
         self::removeDurationFromVideoWidget();

--- a/src/ACF/Brands/VOL.php
+++ b/src/ACF/Brands/VOL.php
@@ -26,6 +26,7 @@ class VOL extends Brand
         self::removeChapterItemsFromVideoWidget();
         self::removeThemeFromTeaserListPageWidget();
         self::removeSortByEditorialTypeFromTeaserListPageWidget();
+        self::removeAdvancedSortByFieldsFromTeaserListPageWidget();
         self::removeTitleFromAssociatedCompositesWidget();
         self::removeDisplayHintFromAssociatedCompositesWidget();
         self::removeDurationFromVideoWidget();

--- a/src/Helpers/AcfName.php
+++ b/src/Helpers/AcfName.php
@@ -43,8 +43,8 @@ class AcfName
     const FIELD_USER = 'user';
     const FIELD_INCLUDE_CATEGORY_CHILDREN = 'include_category_children';
     const FIELD_CATEGORY_TAG_RELATION = 'category_tag_relation';
-    const FIELD_CATEGORY_OPERATION = 'category_operation';
-    const FIELD_TAG_OPERATION = 'tag_operation';
+    const FIELD_CATEGORY_OPERATOR = 'category_operator';
+    const FIELD_TAG_OPERATOR = 'tag_operator';
 
     const WIDGET_BANNER_PLACEMENT = 'banner_placement';
     const WIDGET_FEATURED_CONTENT = 'featured_content';

--- a/src/Helpers/AcfName.php
+++ b/src/Helpers/AcfName.php
@@ -43,6 +43,7 @@ class AcfName
     const FIELD_USER = 'user';
     const FIELD_INCLUDE_CATEGORY_CHILDREN = 'include_category_children';
     const FIELD_CATEGORY_TAG_RELATION = 'category_tag_relation';
+    const FIELD_CATEGORY_OPERATION = 'category_operation';
     const FIELD_TAG_OPERATION = 'tag_operation';
 
     const WIDGET_BANNER_PLACEMENT = 'banner_placement';

--- a/src/Helpers/AcfName.php
+++ b/src/Helpers/AcfName.php
@@ -41,10 +41,10 @@ class AcfName
     const FIELD_AUTHOR = 'author';
     const FIELD_COMPOSITE_CONTENT = 'composite_content';
     const FIELD_USER = 'user';
-    const FIELD_INCLUDE_CATEGORY_CHILDREN = 'include_category_children';
-    const FIELD_CATEGORY_TAG_RELATION = 'category_tag_relation';
-    const FIELD_CATEGORY_OPERATOR = 'category_operator';
-    const FIELD_TAG_OPERATOR = 'tag_operator';
+    const FIELD_INCLUDE_CHILDREN = 'include_children';
+    const FIELD_CATEGORIES_TAGS_RELATION = 'categories_tags_relation';
+    const FIELD_CATEGORIES_OPERATOR = 'categories_operator';
+    const FIELD_TAGS_OPERATOR = 'tags_operator';
 
     const WIDGET_BANNER_PLACEMENT = 'banner_placement';
     const WIDGET_FEATURED_CONTENT = 'featured_content';

--- a/src/Helpers/AcfName.php
+++ b/src/Helpers/AcfName.php
@@ -41,6 +41,9 @@ class AcfName
     const FIELD_AUTHOR = 'author';
     const FIELD_COMPOSITE_CONTENT = 'composite_content';
     const FIELD_USER = 'user';
+    const FIELD_INCLUDE_CATEGORY_CHILDREN = 'include_category_children';
+    const FIELD_CATEGORY_TAG_RELATION = 'category_tag_relation';
+    const FIELD_TAG_OPERATION = 'tag_operation';
 
     const WIDGET_BANNER_PLACEMENT = 'banner_placement';
     const WIDGET_FEATURED_CONTENT = 'featured_content';

--- a/src/Helpers/SortBy.php
+++ b/src/Helpers/SortBy.php
@@ -120,7 +120,7 @@ class SortBy
         ];
 
         $taxonomiesArr = [];
-        if (!self::getUsingAdvancedCustomFiltering()) {
+        if (!self::getUsingAdvancedCustomSortBy()) {
             if (self::isWpTerm(self::$acfWidget[AcfName::FIELD_CATEGORY])) {
                 $taxonomiesArr[] = self::getWpQueryItem(self::$acfWidget[AcfName::FIELD_CATEGORY]);
             }
@@ -145,17 +145,15 @@ class SortBy
                     }
                 }
             }
-            $includeCategoryChildren = is_bool(self::$acfWidget[AcfName::FIELD_INCLUDE_CATEGORY_CHILDREN])
-                ? self::$acfWidget[AcfName::FIELD_INCLUDE_CATEGORY_CHILDREN] : false;
             $taxonomiesSubArr = [
-                'relation' => self::$acfWidget[AcfName::FIELD_CATEGORY_TAG_RELATION]
+                'relation' => self::getRelationValue(AcfName::FIELD_CATEGORY_TAG_RELATION),
             ];
             if (count($categoryTermIds) > 0 && is_array(self::$acfWidget[AcfName::FIELD_CATEGORY])) {
                 $taxonomiesSubArr[] = [
                     'taxonomy' => 'category',
                     'field' => 'term_id',
                     'terms' => $categoryTermIds,
-                    'include_children' => $includeCategoryChildren,
+                    'include_children' => self::getIncludeCategoryChildren(AcfName::FIELD_INCLUDE_CATEGORY_CHILDREN),
                     'operator' => self::getOperatorValue(AcfName::FIELD_CATEGORY_OPERATOR),
                 ];
             }
@@ -322,7 +320,7 @@ class SortBy
         ];
     }
 
-    private static function getUsingAdvancedCustomFiltering(): bool
+    private static function getUsingAdvancedCustomSortBy(): bool
     {
         switch (PageFieldGroup::$brand) {
             case 'IFO' :
@@ -339,6 +337,18 @@ class SortBy
             'field' => 'term_id',
             'terms' => $term->term_id,
         ];
+    }
+
+    private static function getIncludeCategoryChildren(string $fieldName): bool
+    {
+        return is_bool(self::$acfWidget[$fieldName]) ? self::$acfWidget[$fieldName] : false;
+    }
+
+    private static function getRelationValue(string $fieldName): string
+    {
+        $relation = self::$acfWidget[$fieldName];
+        if (is_array($relation) && is_string($relation[0])) return $relation[0];
+        return self::AND;
     }
 
     private static function getOperatorValue(string $fieldName): string

--- a/src/Helpers/SortBy.php
+++ b/src/Helpers/SortBy.php
@@ -153,7 +153,7 @@ class SortBy
                     'taxonomy' => 'category',
                     'field' => 'term_id',
                     'terms' => $categoryTermIds,
-                    'include_children' => self::getIncludeCategoryChildren(AcfName::FIELD_INCLUDE_CHILDREN),
+                    'include_children' => self::getIncludeChildren(AcfName::FIELD_INCLUDE_CHILDREN),
                     'operator' => self::getOperatorValue(AcfName::FIELD_CATEGORIES_OPERATOR),
                 ];
             }
@@ -339,7 +339,7 @@ class SortBy
         ];
     }
 
-    private static function getIncludeCategoryChildren(string $fieldName): bool
+    private static function getIncludeChildren(string $fieldName): bool
     {
         return is_bool(self::$acfWidget[$fieldName]) ? self::$acfWidget[$fieldName] : false;
     }

--- a/src/Helpers/SortBy.php
+++ b/src/Helpers/SortBy.php
@@ -151,24 +151,20 @@ class SortBy
                 'relation' => self::$acfWidget[AcfName::FIELD_CATEGORY_TAG_RELATION]
             ];
             if (count($categoryTermIds) > 0 && is_array(self::$acfWidget[AcfName::FIELD_CATEGORY])) {
-                $operation = self::$acfWidget[AcfName::FIELD_CATEGORY_OPERATION];
-                if (is_array($operation) && is_string($operation[0])) $operation = $operation[0];
                 $taxonomiesSubArr[] = [
                     'taxonomy' => 'category',
                     'field' => 'term_id',
                     'terms' => $categoryTermIds,
                     'include_children' => $includeCategoryChildren,
-                    'operator' => $operation,
+                    'operator' => self::getOperatorValue(AcfName::FIELD_CATEGORY_OPERATOR),
                 ];
             }
             if (count($tagTermIds) > 0 && self::$acfWidget[AcfName::FIELD_TAG]) {
-                $operation = self::$acfWidget[AcfName::FIELD_TAG_OPERATION];
-                if (is_array($operation) && is_string($operation[0])) $operation = $operation[0];
                 $taxonomiesSubArr[] = [
                     'taxonomy' => 'post_tag',
                     'field' => 'term_id',
                     'terms' => $tagTermIds,
-                    'operator' => $operation,
+                    'operator' => self::getOperatorValue(AcfName::FIELD_TAG_OPERATOR),
                 ];
             }
             $taxonomiesArr['relation'] = 'AND';
@@ -343,6 +339,13 @@ class SortBy
             'field' => 'term_id',
             'terms' => $term->term_id,
         ];
+    }
+
+    private static function getOperatorValue(string $fieldName): string
+    {
+        $operation = self::$acfWidget[$fieldName];
+        if (is_array($operation) && is_string($operation[0])) return $operation[0];
+        return self::IN;
     }
 
     /**

--- a/src/Helpers/SortBy.php
+++ b/src/Helpers/SortBy.php
@@ -347,6 +347,7 @@ class SortBy
     private static function getRelationValue(string $fieldName): string
     {
         $relation = self::$acfWidget[$fieldName];
+        if (is_string($relation)) return $relation;
         if (is_array($relation) && is_string($relation[0])) return $relation[0];
         return self::AND;
     }
@@ -354,6 +355,7 @@ class SortBy
     private static function getOperatorValue(string $fieldName): string
     {
         $operation = self::$acfWidget[$fieldName];
+        if (is_string($operation)) return $operation;
         if (is_array($operation) && is_string($operation[0])) return $operation[0];
         return self::IN;
     }

--- a/src/Helpers/SortBy.php
+++ b/src/Helpers/SortBy.php
@@ -146,15 +146,15 @@ class SortBy
                 }
             }
             $taxonomiesSubArr = [
-                'relation' => self::getRelationValue(AcfName::FIELD_CATEGORY_TAG_RELATION),
+                'relation' => self::getRelationValue(AcfName::FIELD_CATEGORIES_TAGS_RELATION),
             ];
             if (count($categoryTermIds) > 0 && is_array(self::$acfWidget[AcfName::FIELD_CATEGORY])) {
                 $taxonomiesSubArr[] = [
                     'taxonomy' => 'category',
                     'field' => 'term_id',
                     'terms' => $categoryTermIds,
-                    'include_children' => self::getIncludeCategoryChildren(AcfName::FIELD_INCLUDE_CATEGORY_CHILDREN),
-                    'operator' => self::getOperatorValue(AcfName::FIELD_CATEGORY_OPERATOR),
+                    'include_children' => self::getIncludeCategoryChildren(AcfName::FIELD_INCLUDE_CHILDREN),
+                    'operator' => self::getOperatorValue(AcfName::FIELD_CATEGORIES_OPERATOR),
                 ];
             }
             if (count($tagTermIds) > 0 && self::$acfWidget[AcfName::FIELD_TAG]) {
@@ -162,7 +162,7 @@ class SortBy
                     'taxonomy' => 'post_tag',
                     'field' => 'term_id',
                     'terms' => $tagTermIds,
-                    'operator' => self::getOperatorValue(AcfName::FIELD_TAG_OPERATOR),
+                    'operator' => self::getOperatorValue(AcfName::FIELD_TAGS_OPERATOR),
                 ];
             }
             $taxonomiesArr['relation'] = 'AND';

--- a/src/Helpers/SortBy.php
+++ b/src/Helpers/SortBy.php
@@ -151,19 +151,24 @@ class SortBy
                 'relation' => self::$acfWidget[AcfName::FIELD_CATEGORY_TAG_RELATION]
             ];
             if (count($categoryTermIds) > 0 && is_array(self::$acfWidget[AcfName::FIELD_CATEGORY])) {
+                $operation = self::$acfWidget[AcfName::FIELD_CATEGORY_OPERATION];
+                if (is_array($operation) && is_string($operation[0])) $operation = $operation[0];
                 $taxonomiesSubArr[] = [
                     'taxonomy' => 'category',
                     'field' => 'term_id',
                     'terms' => $categoryTermIds,
                     'include_children' => $includeCategoryChildren,
+                    'operator' => $operation,
                 ];
             }
             if (count($tagTermIds) > 0 && self::$acfWidget[AcfName::FIELD_TAG]) {
+                $operation = self::$acfWidget[AcfName::FIELD_TAG_OPERATION];
+                if (is_array($operation) && is_string($operation[0])) $operation = $operation[0];
                 $taxonomiesSubArr[] = [
                     'taxonomy' => 'post_tag',
                     'field' => 'term_id',
                     'terms' => $tagTermIds,
-                    'operator' => self::$acfWidget[AcfName::FIELD_TAG_OPERATION],
+                    'operator' => $operation,
                 ];
             }
             $taxonomiesArr['relation'] = 'AND';

--- a/src/Models/ACF/Page/SortByFields.php
+++ b/src/Models/ACF/Page/SortByFields.php
@@ -40,11 +40,11 @@ class SortByFields
         return array_merge($fields, [
             self::getSkipTeasersAmountField(),
             self::getTeaserListField(),
-            self::getCategoryField(),
-            self::getTagField(),
             self::getIncludeCategoryChildrenField(),
             self::getCategoryTagRelationField(),
             self::getTagRelationField(),
+            self::getCategoryField(),
+            self::getTagField(),
             self::getEditorialTypeField(),
             self::getUserField(),
         ]);

--- a/src/Models/ACF/Page/SortByFields.php
+++ b/src/Models/ACF/Page/SortByFields.php
@@ -42,7 +42,8 @@ class SortByFields
             self::getTeaserListField(),
             self::getIncludeCategoryChildrenField(),
             self::getCategoryTagRelationField(),
-            self::getTagRelationField(),
+            self::getCategoryOperationField(),
+            self::getTagOperationField(),
             self::getCategoryField(),
             self::getTagField(),
             self::getEditorialTypeField(),
@@ -245,7 +246,7 @@ class SortByFields
         $field->setLabel('Include category children')
             ->setName(AcfName::FIELD_INCLUDE_CATEGORY_CHILDREN)
             ->setConditionalLogic($condition)
-            ->setWrapper((new ACFWrapper())->setWidth('33'))
+            ->setWrapper((new ACFWrapper())->setWidth('50'))
             ->setDefaultValue(true);
 
         return apply_filters(sprintf('willow/acf/field=%s', $field->getKey()), $field);
@@ -260,7 +261,7 @@ class SortByFields
         $field->setLabel('Category/tags relation')
             ->setName(AcfName::FIELD_CATEGORY_TAG_RELATION)
             ->setConditionalLogic($condition)
-            ->setWrapper((new ACFWrapper())->setWidth('34'))
+            ->setWrapper((new ACFWrapper())->setWidth('50'))
             ->addChoice(SortBy::AND, 'And')
             ->addChoice(SortBy::OR, 'Or')
             ->setDefaultValue([SortBy::AND, 'And'])
@@ -269,7 +270,26 @@ class SortByFields
         return apply_filters(sprintf('willow/acf/field=%s', $field->getKey()), $field);
     }
 
-    private static function getTagRelationField(): ACFField
+    private static function getCategoryOperationField(): ACFField
+    {
+        $condition = new ACFConditionalLogic();
+        $condition->add(self::$sortByField, ACFConditionalLogic::OPERATOR_EQUALS, SortBy::CUSTOM);
+
+        $field = new SelectField(sprintf('field_%s', hash('md5', self::$widgetName . AcfName::FIELD_CATEGORY_OPERATION)));
+        $field->setLabel('Category operation')
+            ->setName(AcfName::FIELD_CATEGORY_OPERATION)
+            ->setConditionalLogic($condition)
+            ->setWrapper((new ACFWrapper())->setWidth('50'))
+            ->addChoice(SortBy::AND, 'And')
+            ->addChoice(SortBy::IN, 'In')
+            ->addChoice(SortBy::NOT_IN, 'Not in')
+            ->setDefaultValue([SortBy::IN, 'In'])
+            ->setReturnFormat(ACFField::RETURN_VALUE);
+
+        return apply_filters(sprintf('willow/acf/field=%s', $field->getKey()), $field);
+    }
+
+    private static function getTagOperationField(): ACFField
     {
         $condition = new ACFConditionalLogic();
         $condition->add(self::$sortByField, ACFConditionalLogic::OPERATOR_EQUALS, SortBy::CUSTOM);
@@ -278,11 +298,11 @@ class SortByFields
         $field->setLabel('Tag operation')
             ->setName(AcfName::FIELD_TAG_OPERATION)
             ->setConditionalLogic($condition)
-            ->setWrapper((new ACFWrapper())->setWidth('33'))
+            ->setWrapper((new ACFWrapper())->setWidth('50'))
             ->addChoice(SortBy::AND, 'And')
             ->addChoice(SortBy::IN, 'In')
             ->addChoice(SortBy::NOT_IN, 'Not in')
-            ->setDefaultValue([SortBy::OR, 'Or'])
+            ->setDefaultValue([SortBy::IN, 'In'])
             ->setReturnFormat(ACFField::RETURN_VALUE);
 
         return apply_filters(sprintf('willow/acf/field=%s', $field->getKey()), $field);

--- a/src/Models/ACF/Page/SortByFields.php
+++ b/src/Models/ACF/Page/SortByFields.php
@@ -40,7 +40,7 @@ class SortByFields
         return array_merge($fields, [
             self::getSkipTeasersAmountField(),
             self::getTeaserListField(),
-            self::getIncludeCategoryChildrenField(),
+            self::getIncludeChildrenField(),
             self::getCategoriesTagsRelationField(),
             self::getCategoriesOperatorField(),
             self::getTagsOperatorField(),
@@ -237,7 +237,7 @@ class SortByFields
         return apply_filters(sprintf('willow/acf/field=%s', $field->getKey()), $field);
     }
 
-    private static function getIncludeCategoryChildrenField(): ACFField
+    private static function getIncludeChildrenField(): ACFField
     {
         $field = new TrueFalseField(sprintf('field_%s', hash('md5', self::$widgetName . AcfName::FIELD_INCLUDE_CHILDREN)));
         $field->setLabel('Include children')

--- a/src/Models/ACF/Page/SortByFields.php
+++ b/src/Models/ACF/Page/SortByFields.php
@@ -42,8 +42,8 @@ class SortByFields
             self::getTeaserListField(),
             self::getIncludeCategoryChildrenField(),
             self::getCategoryTagRelationField(),
-            self::getCategoryOperationField(),
-            self::getTagOperationField(),
+            self::getCategoryOperatorField(),
+            self::getTagOperatorField(),
             self::getCategoryField(),
             self::getTagField(),
             self::getEditorialTypeField(),
@@ -264,7 +264,7 @@ class SortByFields
         return apply_filters(sprintf('willow/acf/field=%s', $field->getKey()), $field);
     }
 
-    private static function getCategoryOperationField(): ACFField
+    private static function getCategoryOperatorField(): ACFField
     {
         $field = new SelectField(sprintf('field_%s', hash('md5', self::$widgetName . AcfName::FIELD_CATEGORY_OPERATOR)));
         $field->setLabel('Category operator')
@@ -279,7 +279,7 @@ class SortByFields
         return apply_filters(sprintf('willow/acf/field=%s', $field->getKey()), $field);
     }
 
-    private static function getTagOperationField(): ACFField
+    private static function getTagOperatorField(): ACFField
     {
         $field = new SelectField(sprintf('field_%s', hash('md5', self::$widgetName . AcfName::FIELD_TAG_OPERATOR)));
         $field->setLabel('Tag operator')

--- a/src/Models/ACF/Page/SortByFields.php
+++ b/src/Models/ACF/Page/SortByFields.php
@@ -8,8 +8,10 @@ use Bonnier\Willow\Base\Models\ACF\ACFField;
 use Bonnier\Willow\Base\Models\ACF\Fields\CustomRelationshipField;
 use Bonnier\Willow\Base\Models\ACF\Fields\NumberField;
 use Bonnier\Willow\Base\Models\ACF\Fields\RadioField;
+use Bonnier\Willow\Base\Models\ACF\Fields\SelectField;
 use Bonnier\Willow\Base\Models\ACF\Fields\TabField;
 use Bonnier\Willow\Base\Models\ACF\Fields\TaxonomyField;
+use Bonnier\Willow\Base\Models\ACF\Fields\TrueFalseField;
 use Bonnier\Willow\Base\Models\ACF\Fields\UserField;
 use Bonnier\Willow\Base\Models\ACF\Properties\ACFConditionalLogic;
 use Bonnier\Willow\Base\Models\ACF\Properties\ACFWrapper;
@@ -40,8 +42,11 @@ class SortByFields
             self::getTeaserListField(),
             self::getCategoryField(),
             self::getTagField(),
+            self::getIncludeCategoryChildrenField(),
+            self::getCategoryTagRelationField(),
+            self::getTagRelationField(),
             self::getEditorialTypeField(),
-            self::getUserField()
+            self::getUserField(),
         ]);
     }
 
@@ -227,6 +232,58 @@ class SortByFields
             ->setAllowNull(true)
             ->setMultiple(false)
             ->setReturnFormat(ACFField::RETURN_ARRAY);
+
+        return apply_filters(sprintf('willow/acf/field=%s', $field->getKey()), $field);
+    }
+
+    private static function getIncludeCategoryChildrenField(): ACFField
+    {
+        $condition = new ACFConditionalLogic();
+        $condition->add(self::$sortByField, ACFConditionalLogic::OPERATOR_EQUALS, SortBy::CUSTOM);
+
+        $field = new TrueFalseField(sprintf('field_%s', hash('md5', self::$widgetName . AcfName::FIELD_INCLUDE_CATEGORY_CHILDREN)));
+        $field->setLabel('Include category children')
+            ->setName(AcfName::FIELD_INCLUDE_CATEGORY_CHILDREN)
+            ->setConditionalLogic($condition)
+            ->setWrapper((new ACFWrapper())->setWidth('33'))
+            ->setDefaultValue(true);
+
+        return apply_filters(sprintf('willow/acf/field=%s', $field->getKey()), $field);
+    }
+
+    private static function getCategoryTagRelationField(): ACFField
+    {
+        $condition = new ACFConditionalLogic();
+        $condition->add(self::$sortByField, ACFConditionalLogic::OPERATOR_EQUALS, SortBy::CUSTOM);
+
+        $field = new SelectField(sprintf('field_%s', hash('md5', self::$widgetName . AcfName::FIELD_CATEGORY_TAG_RELATION)));
+        $field->setLabel('Category/tags relation')
+            ->setName(AcfName::FIELD_CATEGORY_TAG_RELATION)
+            ->setConditionalLogic($condition)
+            ->setWrapper((new ACFWrapper())->setWidth('34'))
+            ->addChoice(SortBy::AND, 'And')
+            ->addChoice(SortBy::OR, 'Or')
+            ->setDefaultValue([SortBy::AND, 'And'])
+            ->setReturnFormat(ACFField::RETURN_VALUE);
+
+        return apply_filters(sprintf('willow/acf/field=%s', $field->getKey()), $field);
+    }
+
+    private static function getTagRelationField(): ACFField
+    {
+        $condition = new ACFConditionalLogic();
+        $condition->add(self::$sortByField, ACFConditionalLogic::OPERATOR_EQUALS, SortBy::CUSTOM);
+
+        $field = new SelectField(sprintf('field_%s', hash('md5', self::$widgetName . AcfName::FIELD_TAG_OPERATION)));
+        $field->setLabel('Tag operation')
+            ->setName(AcfName::FIELD_TAG_OPERATION)
+            ->setConditionalLogic($condition)
+            ->setWrapper((new ACFWrapper())->setWidth('33'))
+            ->addChoice(SortBy::AND, 'And')
+            ->addChoice(SortBy::IN, 'In')
+            ->addChoice(SortBy::NOT_IN, 'Not in')
+            ->setDefaultValue([SortBy::OR, 'Or'])
+            ->setReturnFormat(ACFField::RETURN_VALUE);
 
         return apply_filters(sprintf('willow/acf/field=%s', $field->getKey()), $field);
     }

--- a/src/Models/ACF/Page/SortByFields.php
+++ b/src/Models/ACF/Page/SortByFields.php
@@ -271,7 +271,6 @@ class SortByFields
             ->setName(AcfName::FIELD_CATEGORY_OPERATOR)
             ->setConditionalLogic(self::getAdvancedCustomCondition())
             ->setWrapper((new ACFWrapper())->setWidth('50'))
-            ->addChoice(SortBy::AND, 'And')
             ->addChoice(SortBy::IN, 'In')
             ->addChoice(SortBy::NOT_IN, 'Not in')
             ->setDefaultValue([SortBy::IN, 'In'])

--- a/src/Models/ACF/Page/SortByFields.php
+++ b/src/Models/ACF/Page/SortByFields.php
@@ -239,13 +239,10 @@ class SortByFields
 
     private static function getIncludeCategoryChildrenField(): ACFField
     {
-        $condition = new ACFConditionalLogic();
-        $condition->add(self::$sortByField, ACFConditionalLogic::OPERATOR_EQUALS, SortBy::CUSTOM);
-
         $field = new TrueFalseField(sprintf('field_%s', hash('md5', self::$widgetName . AcfName::FIELD_INCLUDE_CATEGORY_CHILDREN)));
         $field->setLabel('Include category children')
             ->setName(AcfName::FIELD_INCLUDE_CATEGORY_CHILDREN)
-            ->setConditionalLogic($condition)
+            ->setConditionalLogic(self::getAdvancedCustomCondition())
             ->setWrapper((new ACFWrapper())->setWidth('50'))
             ->setDefaultValue(true);
 
@@ -254,13 +251,10 @@ class SortByFields
 
     private static function getCategoryTagRelationField(): ACFField
     {
-        $condition = new ACFConditionalLogic();
-        $condition->add(self::$sortByField, ACFConditionalLogic::OPERATOR_EQUALS, SortBy::CUSTOM);
-
         $field = new SelectField(sprintf('field_%s', hash('md5', self::$widgetName . AcfName::FIELD_CATEGORY_TAG_RELATION)));
         $field->setLabel('Category/tags relation')
             ->setName(AcfName::FIELD_CATEGORY_TAG_RELATION)
-            ->setConditionalLogic($condition)
+            ->setConditionalLogic(self::getAdvancedCustomCondition())
             ->setWrapper((new ACFWrapper())->setWidth('50'))
             ->addChoice(SortBy::AND, 'And')
             ->addChoice(SortBy::OR, 'Or')
@@ -272,13 +266,10 @@ class SortByFields
 
     private static function getCategoryOperationField(): ACFField
     {
-        $condition = new ACFConditionalLogic();
-        $condition->add(self::$sortByField, ACFConditionalLogic::OPERATOR_EQUALS, SortBy::CUSTOM);
-
-        $field = new SelectField(sprintf('field_%s', hash('md5', self::$widgetName . AcfName::FIELD_CATEGORY_OPERATION)));
-        $field->setLabel('Category operation')
-            ->setName(AcfName::FIELD_CATEGORY_OPERATION)
-            ->setConditionalLogic($condition)
+        $field = new SelectField(sprintf('field_%s', hash('md5', self::$widgetName . AcfName::FIELD_CATEGORY_OPERATOR)));
+        $field->setLabel('Category operator')
+            ->setName(AcfName::FIELD_CATEGORY_OPERATOR)
+            ->setConditionalLogic(self::getAdvancedCustomCondition())
             ->setWrapper((new ACFWrapper())->setWidth('50'))
             ->addChoice(SortBy::AND, 'And')
             ->addChoice(SortBy::IN, 'In')
@@ -291,13 +282,10 @@ class SortByFields
 
     private static function getTagOperationField(): ACFField
     {
-        $condition = new ACFConditionalLogic();
-        $condition->add(self::$sortByField, ACFConditionalLogic::OPERATOR_EQUALS, SortBy::CUSTOM);
-
-        $field = new SelectField(sprintf('field_%s', hash('md5', self::$widgetName . AcfName::FIELD_TAG_OPERATION)));
-        $field->setLabel('Tag operation')
-            ->setName(AcfName::FIELD_TAG_OPERATION)
-            ->setConditionalLogic($condition)
+        $field = new SelectField(sprintf('field_%s', hash('md5', self::$widgetName . AcfName::FIELD_TAG_OPERATOR)));
+        $field->setLabel('Tag operator')
+            ->setName(AcfName::FIELD_TAG_OPERATOR)
+            ->setConditionalLogic(self::getAdvancedCustomCondition())
             ->setWrapper((new ACFWrapper())->setWidth('50'))
             ->addChoice(SortBy::AND, 'And')
             ->addChoice(SortBy::IN, 'In')
@@ -326,5 +314,13 @@ class SortByFields
     private static function getDefaultTeaserAmount()
     {
         return array_get(self::$config, 'teaserCountDefault', 4);
+    }
+
+    private static function getAdvancedCustomCondition()
+    {
+        $condition = new ACFConditionalLogic();
+        $condition->add(self::$sortByField, ACFConditionalLogic::OPERATOR_EQUALS, SortBy::CUSTOM);
+
+        return $condition;
     }
 }

--- a/src/Models/ACF/Page/SortByFields.php
+++ b/src/Models/ACF/Page/SortByFields.php
@@ -41,9 +41,9 @@ class SortByFields
             self::getSkipTeasersAmountField(),
             self::getTeaserListField(),
             self::getIncludeCategoryChildrenField(),
-            self::getCategoryTagRelationField(),
-            self::getCategoryOperatorField(),
-            self::getTagOperatorField(),
+            self::getCategoriesTagsRelationField(),
+            self::getCategoriesOperatorField(),
+            self::getTagsOperatorField(),
             self::getCategoryField(),
             self::getTagField(),
             self::getEditorialTypeField(),
@@ -159,7 +159,7 @@ class SortByFields
             ->add(self::$sortByField, ACFConditionalLogic::OPERATOR_EQUALS, SortBy::POPULAR);
 
         $field = new TaxonomyField(sprintf('field_%s', hash('md5', self::$widgetName . AcfName::FIELD_CATEGORY)));
-        $field->setLabel('Category')
+        $field->setLabel($multiSelect ? 'Categories' : 'Category')
             ->setName(AcfName::FIELD_CATEGORY)
             ->setConditionalLogic($condition)
             ->setWrapper((new ACFWrapper())->setWidth('50'))
@@ -182,7 +182,7 @@ class SortByFields
             ->add(self::$sortByField, ACFConditionalLogic::OPERATOR_EQUALS, SortBy::POPULAR);
 
         $field = new TaxonomyField(sprintf('field_%s', hash('md5', self::$widgetName . AcfName::FIELD_TAG)));
-        $field->setLabel('Tag')
+        $field->setLabel($multiSelect ? 'Tags' : 'Tag')
             ->setName(AcfName::FIELD_TAG)
             ->setConditionalLogic($condition)
             ->setWrapper((new ACFWrapper())->setWidth('50'))
@@ -239,9 +239,9 @@ class SortByFields
 
     private static function getIncludeCategoryChildrenField(): ACFField
     {
-        $field = new TrueFalseField(sprintf('field_%s', hash('md5', self::$widgetName . AcfName::FIELD_INCLUDE_CATEGORY_CHILDREN)));
-        $field->setLabel('Include category children')
-            ->setName(AcfName::FIELD_INCLUDE_CATEGORY_CHILDREN)
+        $field = new TrueFalseField(sprintf('field_%s', hash('md5', self::$widgetName . AcfName::FIELD_INCLUDE_CHILDREN)));
+        $field->setLabel('Include children')
+            ->setName(AcfName::FIELD_INCLUDE_CHILDREN)
             ->setConditionalLogic(self::getAdvancedCustomCondition())
             ->setWrapper((new ACFWrapper())->setWidth('50'))
             ->setDefaultValue(true);
@@ -249,11 +249,11 @@ class SortByFields
         return apply_filters(sprintf('willow/acf/field=%s', $field->getKey()), $field);
     }
 
-    private static function getCategoryTagRelationField(): ACFField
+    private static function getCategoriesTagsRelationField(): ACFField
     {
-        $field = new SelectField(sprintf('field_%s', hash('md5', self::$widgetName . AcfName::FIELD_CATEGORY_TAG_RELATION)));
-        $field->setLabel('Category/tags relation')
-            ->setName(AcfName::FIELD_CATEGORY_TAG_RELATION)
+        $field = new SelectField(sprintf('field_%s', hash('md5', self::$widgetName . AcfName::FIELD_CATEGORIES_TAGS_RELATION)));
+        $field->setLabel('Categories/tags relation')
+            ->setName(AcfName::FIELD_CATEGORIES_TAGS_RELATION)
             ->setConditionalLogic(self::getAdvancedCustomCondition())
             ->setWrapper((new ACFWrapper())->setWidth('50'))
             ->addChoice(SortBy::AND, 'And')
@@ -264,11 +264,11 @@ class SortByFields
         return apply_filters(sprintf('willow/acf/field=%s', $field->getKey()), $field);
     }
 
-    private static function getCategoryOperatorField(): ACFField
+    private static function getCategoriesOperatorField(): ACFField
     {
-        $field = new SelectField(sprintf('field_%s', hash('md5', self::$widgetName . AcfName::FIELD_CATEGORY_OPERATOR)));
-        $field->setLabel('Category operator')
-            ->setName(AcfName::FIELD_CATEGORY_OPERATOR)
+        $field = new SelectField(sprintf('field_%s', hash('md5', self::$widgetName . AcfName::FIELD_CATEGORIES_OPERATOR)));
+        $field->setLabel('Categories operator')
+            ->setName(AcfName::FIELD_CATEGORIES_OPERATOR)
             ->setConditionalLogic(self::getAdvancedCustomCondition())
             ->setWrapper((new ACFWrapper())->setWidth('50'))
             ->addChoice(SortBy::IN, 'In')
@@ -279,11 +279,11 @@ class SortByFields
         return apply_filters(sprintf('willow/acf/field=%s', $field->getKey()), $field);
     }
 
-    private static function getTagOperatorField(): ACFField
+    private static function getTagsOperatorField(): ACFField
     {
-        $field = new SelectField(sprintf('field_%s', hash('md5', self::$widgetName . AcfName::FIELD_TAG_OPERATOR)));
-        $field->setLabel('Tag operator')
-            ->setName(AcfName::FIELD_TAG_OPERATOR)
+        $field = new SelectField(sprintf('field_%s', hash('md5', self::$widgetName . AcfName::FIELD_TAGS_OPERATOR)));
+        $field->setLabel('Tags operator')
+            ->setName(AcfName::FIELD_TAGS_OPERATOR)
             ->setConditionalLogic(self::getAdvancedCustomCondition())
             ->setWrapper((new ACFWrapper())->setWidth('50'))
             ->addChoice(SortBy::AND, 'And')

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/benjaminmedia/willow-base-theme
 Author: Bonnier Publications
 Author URI: https://github.com/benjaminmedia
 Description: Willow Base theme for WordPress - A full WordPress REST API - no frontend at all.
-Version: 4.46.6
+Version: 4.47.0
 License: GNU General Public License
 License URI: https://www.gnu.org/licenses/gpl.html
 */


### PR DESCRIPTION
Adding more advanced options to teaserlist taxonomy sortby functions

- adding "include category children" True/False checkbox
- adding "Category/tag relation" select('And', 'Or')
- adding "Category operator" select('In', 'Not in'). 
      - NOTE no 'And' here, an article cant be i more than one category anyway.
- adding "Tags operator" select('And', 'In', 'Not in')
- changed "tax_query" to match new values and output.
      - NOTE only changed if using advanced custom taxonomy in teaserlist like iform :)
- remove from other brands than IFO.

![image](https://user-images.githubusercontent.com/404800/118025416-1d9d1c00-b360-11eb-868a-c442a6e4774d.png)
