### PR TITLE
IFD-345/Category-pages-include-child-and-grandchild

### DIFF
--- a/src/Adapters/Cxense/Search/CategoryAdapter.php
+++ b/src/Adapters/Cxense/Search/CategoryAdapter.php
@@ -61,7 +61,7 @@ class CategoryAdapter implements CategoryContract
         return null;
     }
 
-    public function getContentTeasers($page, $perPage, $orderBy, $order, $offset): Collection
+    public function getContentTeasers($page, $perPage, $orderBy, $order, $offset, $includeChildren): Collection
     {
         return collect();
     }

--- a/src/Adapters/Wp/Terms/Categories/CategoryAdapter.php
+++ b/src/Adapters/Wp/Terms/Categories/CategoryAdapter.php
@@ -138,7 +138,8 @@ class CategoryAdapter extends AbstractWpAdapter implements CategoryContract
         $perPage = 10,
         $orderBy = 'date',
         $order = 'DESC',
-        $offset = 0
+        $offset = 0,
+        $includeChildren = 'false'
     ): Collection {
         global $wpdb;
         $excludedFromWebIds = $wpdb->get_col("SELECT post_id FROM wp_postmeta WHERE meta_key='exclude_platforms' and meta_value like '%web%'");
@@ -156,7 +157,7 @@ class CategoryAdapter extends AbstractWpAdapter implements CategoryContract
                     'taxonomy' => 'category',
                     'field' => 'term_id',
                     'terms' => $this->getId(),
-                    'include_children' => false,
+                    'include_children' => $includeChildren == 'true',
                 ]
             ]
         ]))->map(function (\WP_Post $post) {

--- a/src/Models/Base/Terms/Category.php
+++ b/src/Models/Base/Terms/Category.php
@@ -62,9 +62,9 @@ class Category implements CategoryContract
         return $this->category->getLanguage();
     }
 
-    public function getContentTeasers($page, $perPage, $orderBy, $order, $offset): Collection
+    public function getContentTeasers($page, $perPage, $orderBy, $order, $offset, $includeChildren): Collection
     {
-        return $this->category->getContentTeasers($page, $perPage, $orderBy, $order, $offset);
+        return $this->category->getContentTeasers($page, $perPage, $orderBy, $order, $offset, $includeChildren);
     }
 
     public function getCount(): ?int

--- a/src/Models/Contracts/Terms/CategoryContract.php
+++ b/src/Models/Contracts/Terms/CategoryContract.php
@@ -24,7 +24,7 @@ interface CategoryContract
 
     public function getLanguage(): ?string;
 
-    public function getContentTeasers($page, $perPage, $orderBy, $order, $offset): Collection;
+    public function getContentTeasers($page, $perPage, $orderBy, $order, $offset, $includeChildren): Collection;
 
     public function getCount(): ?int;
 

--- a/src/Transformers/Api/Terms/Category/CategoryTransformer.php
+++ b/src/Transformers/Api/Terms/Category/CategoryTransformer.php
@@ -85,9 +85,10 @@ class CategoryTransformer extends TransformerAbstract
         list($orderby) = $paramBag->get('orderby') ?: ['date'];
         list($order) = $paramBag->get('order') ?: ['DESC'];
         list($offset) = $paramBag->get('offset') ?: ['0'];
+        list($includeChildren) = $paramBag->get('include_children') ?: ['false'];
 
         return $this->collection(
-            $category->getContentTeasers($page, $perPage, $orderby, $order, $offset),
+            $category->getContentTeasers($page, $perPage, $orderby, $order, $offset, $includeChildren),
             new CompositeTeaserTransformer()
         );
     }

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/benjaminmedia/willow-base-theme
 Author: Bonnier Publications
 Author URI: https://github.com/benjaminmedia
 Description: Willow Base theme for WordPress - A full WordPress REST API - no frontend at all.
-Version: 4.48.9
+Version: 4.49.0
 License: GNU General Public License
 License URI: https://www.gnu.org/licenses/gpl.html
 */


### PR DESCRIPTION
adding content-teasers:include_children(true) to category api endpoint to be able to include children posts of the category.